### PR TITLE
Register the web proxy in the DI

### DIFF
--- a/src/Processor/Program.cs
+++ b/src/Processor/Program.cs
@@ -1,6 +1,7 @@
 using Defra.TradeImportsProcessor.Processor.Configuration;
 using Defra.TradeImportsProcessor.Processor.Extensions;
 using Defra.TradeImportsProcessor.Processor.Utils;
+using Defra.TradeImportsProcessor.Processor.Utils.Http;
 using Defra.TradeImportsProcessor.Processor.Utils.Logging;
 using Microsoft.AspNetCore.Diagnostics;
 using Serilog;
@@ -65,7 +66,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
         if (!string.IsNullOrWhiteSpace(traceHeader))
             options.Headers.Add(traceHeader);
     });
+
     builder.Services.AddOptions<CdpOptions>();
+    builder.Services.AddHttpProxyClient();
+
     builder.Services.AddConsumers(builder.Configuration);
 }
 


### PR DESCRIPTION
This was missing but the IWebProxy is only required when running in CDP.