### PR TITLE
CDMS-487: Add packages: read permission to the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
+  packages: read
 
 env:
   AWS_REGION: eu-west-2


### PR DESCRIPTION
The pipeline is currently failing.  I think this may give the sub-workflow permission to read the packages.