### PR TITLE
CDMS-487: Always accept every message coming to the consumer

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using Azure.Messaging.ServiceBus;
 using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsProcessor.Processor.Configuration;
 using Defra.TradeImportsProcessor.Processor.Consumers;
-using Defra.TradeImportsProcessor.Processor.Models.ImportNotification;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using SlimMessageBus.Host;
@@ -68,12 +67,13 @@ public static class ServiceCollectionExtensions
                     ConfigureServiceBusClient(cbb, serviceBusOptions.Notifications.ConnectionString);
 
                     cbb.AddServicesFromAssemblyContaining<NotificationConsumer>()
-                        .Consume<ImportNotification>(x =>
+                        .Consume<object>(x =>
+                        {
                             x.Topic(serviceBusOptions.Notifications.Topic)
                                 .SubscriptionName(serviceBusOptions.Notifications.Subscription)
                                 .WithConsumer<NotificationConsumer>()
-                                .Instances(20)
-                        );
+                                .Instances(20);
+                        });
                 }
             );
         });


### PR DESCRIPTION
SlimMessageBus seems to silently discard any messages that come through to it that it doesn't understand or deserialize properly, even with options like `WhenUndeclaredMessageTypeArrives` enabled.

Obviously, this is a huge risk.

We have changed this to be an object and then we handle the deserialization ourselves.