### PR TITLE
Update to pre release 0.3.0 of data API

### DIFF
--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -20,7 +20,7 @@ public class NotificationConsumer(ILogger<object> logger, ITradeImportsDataApiCl
 
         logger.LogInformation("Received notification {ReferenceNumber}", from.ReferenceNumber);
 
-        var to = new IpaffsDataApi.ImportNotification
+        var to = new IpaffsDataApi.ImportPreNotification
         {
             IpaffsId = from.IpaffsId,
             Etag = from.Etag,
@@ -59,7 +59,7 @@ public class NotificationConsumer(ILogger<object> logger, ITradeImportsDataApiCl
         {
             logger.LogInformation(
                 "Updating existing notification {ReferenceNumber}",
-                existingNotification.Data.ReferenceNumber
+                existingNotification.ImportPreNotification.ReferenceNumber
             );
             await api.PutImportNotification(from.ReferenceNumber!, to, existingNotification.ETag, cancellationToken);
             return;

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -54,18 +54,18 @@ public class NotificationConsumer(ILogger<object> logger, ITradeImportsDataApiCl
             IsGMRMatched = from.IsGMRMatched,
         };
 
-        var existingNotification = await api.GetImportNotification(from.ReferenceNumber!, cancellationToken);
+        var existingNotification = await api.GetImportPreNotification(from.ReferenceNumber!, cancellationToken);
         if (existingNotification != null)
         {
             logger.LogInformation(
                 "Updating existing notification {ReferenceNumber}",
                 existingNotification.ImportPreNotification.ReferenceNumber
             );
-            await api.PutImportNotification(from.ReferenceNumber!, to, existingNotification.ETag, cancellationToken);
+            await api.PutImportPreNotification(from.ReferenceNumber!, to, existingNotification.ETag, cancellationToken);
             return;
         }
 
         logger.LogInformation("Creating new notification {ReferenceNumber}", to.ReferenceNumber);
-        await api.PutImportNotification(from.ReferenceNumber!, to, null, cancellationToken);
+        await api.PutImportPreNotification(from.ReferenceNumber!, to, null, cancellationToken);
     }
 }

--- a/src/Processor/Models/ImportNotification/Mappers/ImportNotificationMapper.cs
+++ b/src/Processor/Models/ImportNotification/Mappers/ImportNotificationMapper.cs
@@ -8,13 +8,13 @@ namespace Defra.TradeImportsProcessor.Processor.Models.ImportNotification.Mapper
 
 public static class ImportNotificationMapper
 {
-    public static IpaffsDataApi.ImportNotification Map(ImportNotification? from)
+    public static IpaffsDataApi.ImportPreNotification Map(ImportNotification? from)
     {
         if (from is null)
         {
             return default!;
         }
-        var to = new IpaffsDataApi.ImportNotification();
+        var to = new IpaffsDataApi.ImportPreNotification();
         to.IpaffsId = from?.IpaffsId;
         to.Etag = from?.Etag;
         to.ExternalReferences = from?.ExternalReferences?.Select(x => ExternalReferenceMapper.Map(x)).ToArray();

--- a/src/Processor/Models/ImportNotification/Mappers/ImportNotificationWithTransformMapper.cs
+++ b/src/Processor/Models/ImportNotification/Mappers/ImportNotificationWithTransformMapper.cs
@@ -6,7 +6,7 @@ using IpaffsDataApi = Defra.TradeImportsDataApi.Domain.Ipaffs;
 
 public static class ImportNotificationWithTransformMapper
 {
-    public static IpaffsDataApi.ImportNotification MapWithTransform(this ImportNotification? from)
+    public static IpaffsDataApi.ImportPreNotification MapWithTransform(this ImportNotification? from)
     {
         if (from is null)
         {
@@ -42,7 +42,7 @@ public static class ImportNotificationWithTransformMapper
         return input.ToDictionary(mc => mc.Key.FromSnakeCase(), mc => mc.Value);
     }
 
-    private static void Map(ImportNotification from, IpaffsDataApi.ImportNotification to)
+    private static void Map(ImportNotification from, IpaffsDataApi.ImportPreNotification to)
     {
         var commodities = from.PartOne!.Commodities;
 

--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.2.0-pr-22.135"/>
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.3.0-pr-35.165" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3"/>
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3"/>
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0"/>

--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.3.0-pr-35.165" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.3.0-pr-35.167" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3"/>
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3"/>
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0"/>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+    <ItemGroup Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', 'AutoFixture'))' == 'True'">
+        <!-- AutoFixture@4.18.1 -->
+        <!-- https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(PackageReference->AnyHaveMetadataValue('Identity', 'AutoFixture'))' == 'True'">
+        <!-- AutoFixture@4.18.1 -->
+        <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    </ItemGroup>
+</Project>

--- a/tests/Processor.IntegrationTests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.IntegrationTests/Consumers/NotificationConsumerTests.cs
@@ -22,7 +22,7 @@ public class NotificationConsumerTests : ServiceBusTestBase
         await wireMockAdminApi.ResetMappingsAsync();
         await wireMockAdminApi.ResetRequestsAsync();
 
-        var createPath = $"/import-notifications/{importNotification.ReferenceNumber}";
+        var createPath = $"/import-pre-notifications/{importNotification.ReferenceNumber}";
         var mappingBuilder = wireMockAdminApi.GetMappingBuilder();
         mappingBuilder.Given(m =>
             m.WithRequest(req => req.UsingPut().WithPath(createPath))

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -21,14 +21,14 @@ public class NotificationConsumerTests
         var cancellationToken = CancellationToken.None;
 
         _mockApi
-            .GetImportNotification(importNotification.ReferenceNumber!, cancellationToken)
+            .GetImportPreNotification(importNotification.ReferenceNumber!, cancellationToken)
             .Returns(null as ImportPreNotificationResponse);
 
         await consumer.OnHandle(importNotification, cancellationToken);
 
         await _mockApi
             .Received()
-            .PutImportNotification(
+            .PutImportPreNotification(
                 importNotification.ReferenceNumber!,
                 Arg.Any<IpaffsDataApi.ImportPreNotification>(),
                 null,
@@ -52,13 +52,13 @@ public class NotificationConsumerTests
             expectedEtag
         );
 
-        _mockApi.GetImportNotification(importNotification.ReferenceNumber!, cancellationToken).Returns(response);
+        _mockApi.GetImportPreNotification(importNotification.ReferenceNumber!, cancellationToken).Returns(response);
 
         await consumer.OnHandle(importNotification, cancellationToken);
 
         await _mockApi
             .Received()
-            .PutImportNotification(
+            .PutImportPreNotification(
                 importNotification.ReferenceNumber!,
                 Arg.Any<IpaffsDataApi.ImportPreNotification>(),
                 expectedEtag,

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -22,7 +22,7 @@ public class NotificationConsumerTests
 
         _mockApi
             .GetImportNotification(importNotification.ReferenceNumber!, cancellationToken)
-            .Returns(null as ImportNotificationResponse);
+            .Returns(null as ImportPreNotificationResponse);
 
         await consumer.OnHandle(importNotification, cancellationToken);
 
@@ -30,7 +30,7 @@ public class NotificationConsumerTests
             .Received()
             .PutImportNotification(
                 importNotification.ReferenceNumber!,
-                Arg.Any<IpaffsDataApi.ImportNotification>(),
+                Arg.Any<IpaffsDataApi.ImportPreNotification>(),
                 null,
                 cancellationToken
             );
@@ -45,7 +45,7 @@ public class NotificationConsumerTests
         var dataApiImportNotification = DataApiImportNotificationFixture();
         var cancellationToken = CancellationToken.None;
         const string expectedEtag = "12345";
-        var response = new ImportNotificationResponse(
+        var response = new ImportPreNotificationResponse(
             dataApiImportNotification,
             DateTime.Now,
             DateTime.Now,
@@ -60,7 +60,7 @@ public class NotificationConsumerTests
             .Received()
             .PutImportNotification(
                 importNotification.ReferenceNumber!,
-                Arg.Any<IpaffsDataApi.ImportNotification>(),
+                Arg.Any<IpaffsDataApi.ImportPreNotification>(),
                 expectedEtag,
                 cancellationToken
             );

--- a/tests/TestFixtures/ImportNotificationFixtures.cs
+++ b/tests/TestFixtures/ImportNotificationFixtures.cs
@@ -20,12 +20,12 @@ public static class ImportNotificationFixtures
             .Create();
     }
 
-    public static TradeImportsDataApi.Domain.Ipaffs.ImportNotification DataApiImportNotificationFixture()
+    public static TradeImportsDataApi.Domain.Ipaffs.ImportPreNotification DataApiImportNotificationFixture()
     {
         var fixture = GetFixture();
 
         return fixture
-            .Build<TradeImportsDataApi.Domain.Ipaffs.ImportNotification>()
+            .Build<TradeImportsDataApi.Domain.Ipaffs.ImportPreNotification>()
             .With(i => i.ReferenceNumber, "CHEDP.GB.2025.1234567") // TO-DO: Randomize
             .Create();
     }

--- a/tests/TestFixtures/TestFixtures.csproj
+++ b/tests/TestFixtures/TestFixtures.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-      <AssemblyName>Defra.TradeImportsProcessor.TestFixtures</AssemblyName>
-      <RootNamespace>Defra.TradeImportsProcessor.TestFixtures</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Defra.TradeImportsProcessor.TestFixtures</AssemblyName>
+    <RootNamespace>Defra.TradeImportsProcessor.TestFixtures</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Processor\Processor.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Processor\Processor.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="AutoFixture" Version="4.18.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Pull in changes from 0.3.0 pre release from PR https://github.com/DEFRA/trade-imports-data-api/pull/35.

Further work on the above PR is needed as endpoint paths have also changed.

Also fixed a package security warning. This might not have triggered in the pipeline as it was for a testing dependency and not related to code that would have made it into the final Docker image.