### PR TITLE
CDMS-134: Add test to ensure cancelled or deleted notifications are sent to the Data API

### DIFF
--- a/tests/TestFixtures/ImportNotificationFixtures.cs
+++ b/tests/TestFixtures/ImportNotificationFixtures.cs
@@ -8,6 +8,8 @@ namespace Defra.TradeImportsProcessor.TestFixtures;
 
 public static class ImportNotificationFixtures
 {
+    private static readonly List<string> s_chedTypes = ["A", "D", "P", "PP"];
+
     private static Fixture GetFixture()
     {
         var fixture = new Fixture();
@@ -15,11 +17,20 @@ public static class ImportNotificationFixtures
         return fixture;
     }
 
+    private static string GenerateReferenceNumber()
+    {
+        var chedType = s_chedTypes[new Random().Next(s_chedTypes.Count)];
+        var currentYear = DateTime.Now.Year;
+        var number = new Random().Next(1000000, 10000000);
+
+        return $"CHED{chedType}.GB.{currentYear}.{number}";
+    }
+
     public static IPostprocessComposer<ImportNotification> ImportNotificationFixture()
     {
         return GetFixture()
             .Build<ImportNotification>()
-            .With(i => i.ReferenceNumber, "CHEDP.GB.2025.1234567") // TO-DO: Randomize
+            .With(i => i.ReferenceNumber, GenerateReferenceNumber()) // TO-DO: Randomize
             .With(i => i.Status, ImportNotificationStatus.InProgress);
     }
 
@@ -27,6 +38,6 @@ public static class ImportNotificationFixtures
     {
         var fixture = GetFixture();
 
-        return fixture.Build<ImportPreNotification>().With(i => i.ReferenceNumber, "CHEDP.GB.2025.1234567"); // TO-DO: Randomize
+        return fixture.Build<ImportPreNotification>().With(i => i.ReferenceNumber, GenerateReferenceNumber()); // TO-DO: Randomize
     }
 }

--- a/tests/TestFixtures/ImportNotificationFixtures.cs
+++ b/tests/TestFixtures/ImportNotificationFixtures.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System.Security.Cryptography;
+using AutoFixture;
 using AutoFixture.Dsl;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using Defra.TradeImportsProcessor.Processor.Models.ImportNotification;
@@ -19,9 +20,9 @@ public static class ImportNotificationFixtures
 
     private static string GenerateReferenceNumber()
     {
-        var chedType = s_chedTypes[new Random().Next(s_chedTypes.Count)];
+        var chedType = s_chedTypes[RandomNumberGenerator.GetInt32(0, s_chedTypes.Count)];
         var currentYear = DateTime.Now.Year;
-        var number = new Random().Next(1000000, 10000000);
+        var number = RandomNumberGenerator.GetInt32(1000000, 10000000);
 
         return $"CHED{chedType}.GB.{currentYear}.{number}";
     }


### PR DESCRIPTION
A bit of a redundant test but it covers off the functionality of the old system.