### PR TITLE
CDMS-135: Discard old ClearanceRequests

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -84,13 +84,15 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
 
         if (
             existingCustomsDeclaration.ClearanceRequest != null
-            && NewClearanceRequestIsOlderThanExistingClearanceRequest(
-                newClearanceRequest,
-                existingCustomsDeclaration.ClearanceRequest
-            )
+            && IsClearanceRequestOlderThan(newClearanceRequest, existingCustomsDeclaration.ClearanceRequest)
         )
         {
-            logger.LogInformation("Skipping {Mrn} because new clearance request is older than existing", mrn);
+            logger.LogInformation(
+                "Skipping {Mrn} because new clearance request {NewClearanceVersion} is older than existing {ExistingClearanceVersion}",
+                mrn,
+                newClearanceRequest.ExternalVersion,
+                existingCustomsDeclaration.ClearanceRequest.ExternalVersion
+            );
             return;
         }
 
@@ -110,7 +112,7 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
         );
     }
 
-    private static bool NewClearanceRequestIsOlderThanExistingClearanceRequest(
+    private static bool IsClearanceRequestOlderThan(
         DataApiCustomsDeclaration.ClearanceRequest newClearanceRequest,
         DataApiCustomsDeclaration.ClearanceRequest existingClearanceRequest
     )

--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -23,7 +23,7 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
 
         var mrn = clearanceRequest.Header.EntryReference!;
 
-        var to = new DataApiCustomsDeclaration.ClearanceRequest
+        var newClearanceRequest = new DataApiCustomsDeclaration.ClearanceRequest
         {
             ExternalCorrelationId = clearanceRequest.ServiceHeader.CorrelationId,
             MessageSentAt = clearanceRequest.ServiceHeader.ServiceCallTimestamp,
@@ -73,16 +73,31 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
         if (existingCustomsDeclaration == null)
         {
             logger.LogInformation("Creating new customs declaration {Mrn}", mrn);
-            var newCustomsDeclaration = new DataApiCustomsDeclaration.CustomsDeclaration { ClearanceRequest = to };
+            var newCustomsDeclaration = new DataApiCustomsDeclaration.CustomsDeclaration
+            {
+                ClearanceRequest = newClearanceRequest,
+            };
 
             await api.PutCustomsDeclaration(mrn, newCustomsDeclaration, null, cancellationToken);
+            return;
+        }
+
+        if (
+            existingCustomsDeclaration.ClearanceRequest != null
+            && NewClearanceRequestIsOlderThanExistingClearanceRequest(
+                newClearanceRequest,
+                existingCustomsDeclaration.ClearanceRequest
+            )
+        )
+        {
+            logger.LogInformation("Skipping {Mrn} because new clearance request is older than existing", mrn);
             return;
         }
 
         var updatedCustomsDeclaration = new DataApiCustomsDeclaration.CustomsDeclaration
         {
             ClearanceDecision = existingCustomsDeclaration.ClearanceDecision,
-            ClearanceRequest = to,
+            ClearanceRequest = newClearanceRequest,
             Finalisation = existingCustomsDeclaration.Finalisation,
         };
 
@@ -93,5 +108,13 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
             existingCustomsDeclaration.ETag,
             cancellationToken
         );
+    }
+
+    private static bool NewClearanceRequestIsOlderThanExistingClearanceRequest(
+        DataApiCustomsDeclaration.ClearanceRequest newClearanceRequest,
+        DataApiCustomsDeclaration.ClearanceRequest existingClearanceRequest
+    )
+    {
+        return newClearanceRequest.ExternalVersion < existingClearanceRequest.ExternalVersion;
     }
 }

--- a/tests/TestFixtures/ClearanceRequestFixtures.cs
+++ b/tests/TestFixtures/ClearanceRequestFixtures.cs
@@ -13,20 +13,22 @@ public static class ClearanceRequestFixtures
         return new Fixture();
     }
 
-    private static Header GenerateHeader(string? mrn = null)
+    private static Header GenerateHeader(int version, string? mrn = null)
     {
-        return GetFixture().Build<Header>().With(h => h.EntryReference, mrn ?? GenerateMrn()).Create();
+        return GetFixture()
+            .Build<Header>()
+            .With(h => h.EntryReference, mrn ?? GenerateMrn())
+            .With(h => h.EntryVersionNumber, version)
+            .Create();
     }
 
-    public static IPostprocessComposer<ClearanceRequest> ClearanceRequestFixture(string? mrn = null)
+    public static IPostprocessComposer<ClearanceRequest> ClearanceRequestFixture(string? mrn = null, int version = 2)
     {
-        return GetFixture().Build<ClearanceRequest>().With(c => c.Header, GenerateHeader(mrn));
+        return GetFixture().Build<ClearanceRequest>().With(c => c.Header, GenerateHeader(version, mrn));
     }
 
-    public static IPostprocessComposer<DataApiCustomsDeclaration.ClearanceRequest> DataApiClearanceRequestFixture(
-        string? mrn = null
-    )
+    public static IPostprocessComposer<DataApiCustomsDeclaration.ClearanceRequest> DataApiClearanceRequestFixture()
     {
-        return GetFixture().Build<DataApiCustomsDeclaration.ClearanceRequest>();
+        return GetFixture().Build<DataApiCustomsDeclaration.ClearanceRequest>().With(c => c.ExternalVersion, 1);
     }
 }


### PR DESCRIPTION
We don't want to save ClearanceRequests that come through when there is a newer version stored within the Data Api.