### PR TITLE
Configure dependabot to use classic PAT (as this is all it supports when private nuget repos are being used)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ registries:
   defra:
     type: nuget-feed
     url: https://nuget.pkg.github.com/DEFRA/index.json
-    token: ${{ secrets.GITHUB_TOKEN }}
+    token: ${{ secrets.DEPENDABOT_PAT }}
 
 updates:
   - package-ecosystem: nuget


### PR DESCRIPTION
As per PR title.