### PR TITLE
CDMS-478: Only persist the Finalisation message if it is a later version

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -140,6 +140,6 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
         DataApiCustomsDeclaration.Finalisation existingFinalisation
     )
     {
-        return newFinalisation.MessageSentAt > existingFinalisation.MessageSentAt;
+        return newFinalisation.ExternalVersion > existingFinalisation.ExternalVersion;
     }
 }

--- a/tests/Processor.Tests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -261,10 +261,10 @@ public class CustomsDeclarationsConsumerTests
         };
 
         var mrn = GenerateMrn();
-        var finalisation = FinalisationFixture(mrn)
+        var finalisation = FinalisationFixture(mrn, 1)
             .With(f => f.ServiceHeader, GenerateServiceHeader(DateTime.UtcNow.AddMinutes(-5)))
             .Create();
-        var existingFinalisation = DataApiFinalisationFixture().With(f => f.MessageSentAt, DateTime.UtcNow).Create();
+        var existingFinalisation = DataApiFinalisationFixture().With(f => f.ExternalVersion, 2).Create();
 
         var response = new CustomsDeclarationResponse(
             mrn,

--- a/tests/TestFixtures/FinalisationFixtures.cs
+++ b/tests/TestFixtures/FinalisationFixtures.cs
@@ -13,20 +13,21 @@ public static class FinalisationFixtures
         return new Fixture();
     }
 
-    private static FinalisationHeader GenerateHeader(string? mrn)
+    private static FinalisationHeader GenerateHeader(int version, string? mrn)
     {
         return GetFixture()
             .Build<FinalisationHeader>()
             .With(f => f.FinalState, "0")
             .With(f => f.EntryReference, mrn ?? GenerateMrn())
+            .With(h => h.EntryVersionNumber, version)
             .Create();
     }
 
-    public static IPostprocessComposer<Finalisation> FinalisationFixture(string? mrn = null)
+    public static IPostprocessComposer<Finalisation> FinalisationFixture(string? mrn = null, int version = 2)
     {
         return GetFixture()
             .Build<Finalisation>()
-            .With(f => f.Header, GenerateHeader(mrn))
+            .With(f => f.Header, GenerateHeader(version, mrn))
             .With(f => f.ServiceHeader, GenerateServiceHeader());
     }
 
@@ -36,6 +37,7 @@ public static class FinalisationFixtures
     {
         return GetFixture()
             .Build<DataApiCustomsDeclaration.Finalisation>()
-            .With(f => f.MessageSentAt, messageSentAt ?? DateTime.UtcNow.AddMinutes(-5));
+            .With(f => f.MessageSentAt, messageSentAt ?? DateTime.UtcNow.AddMinutes(-5))
+            .With(f => f.ExternalVersion, 1);
     }
 }


### PR DESCRIPTION
We have decided to use the `EntryVersionNumber` to establish whether a Finalisation message is later than the existing record, which is what the Clearance Requests does.