### PR TITLE
CDMS-481: Receive InboundErrors from the gateway

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -33,6 +33,7 @@ public class CustomsDeclarationsConsumer(ILogger<CustomsDeclarationsConsumer> lo
                 received,
                 existingCustomsDeclaration
             ),
+            InboundHmrcMessageType.InboundError => null,
             InboundHmrcMessageType.Finalisation => OnHandleFinalisation(mrn, received, existingCustomsDeclaration),
             _ => throw new CustomsDeclarationMessageTypeException(MessageId),
         };

--- a/src/Processor/Models/CustomsDeclarations/InboundError.cs
+++ b/src/Processor/Models/CustomsDeclarations/InboundError.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+
+public class InboundError
+{
+    [JsonPropertyName("header")]
+    public required Header Header { get; init; }
+
+    [JsonPropertyName("serviceHeader")]
+    public required ServiceHeader ServiceHeader { get; init; }
+
+    [JsonPropertyName("errors")]
+    public required InboundErrorItem[] Errors { get; init; }
+}

--- a/src/Processor/Models/CustomsDeclarations/InboundErrorItem.cs
+++ b/src/Processor/Models/CustomsDeclarations/InboundErrorItem.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+
+public class InboundErrorItem
+{
+    [JsonPropertyName("errorCode")]
+    public required string errorCode { get; init; }
+
+    [JsonPropertyName("errorMessage")]
+    public required string errorMessage { get; init; }
+}

--- a/src/Processor/Models/CustomsDeclarations/InboundHmrcMessageType.cs
+++ b/src/Processor/Models/CustomsDeclarations/InboundHmrcMessageType.cs
@@ -3,5 +3,6 @@ namespace Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 public static class InboundHmrcMessageType
 {
     public const string ClearanceRequest = "ClearanceRequest";
+    public const string InboundError = "InboundError";
     public const string Finalisation = "Finalisation";
 }

--- a/tests/TestFixtures/InboundErrorFixtures.cs
+++ b/tests/TestFixtures/InboundErrorFixtures.cs
@@ -1,0 +1,18 @@
+using AutoFixture;
+using AutoFixture.Dsl;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+
+namespace Defra.TradeImportsProcessor.TestFixtures;
+
+public static class InboundErrorFixtures
+{
+    private static Fixture GetFixture()
+    {
+        return new Fixture();
+    }
+
+    public static IPostprocessComposer<InboundError> InboundErrorFixture()
+    {
+        return GetFixture().Build<InboundError>();
+    }
+}


### PR DESCRIPTION
This takes any messages from gateway with the InboundError message type error and discards them until the Data Api is ready to receive them.