### PR TITLE
CDMS-483: Add integration test for Inbound Errors

### DIFF
--- a/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.FinalisationFixtures;
+using static Defra.TradeImportsProcessor.TestFixtures.InboundErrorFixtures;
 
 namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Consumers;
 
@@ -70,9 +71,6 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
         var mrn = GenerateMrn();
         var finalisation = FinalisationFixture(mrn).Create();
 
-        await _wireMockAdminApi.ResetMappingsAsync();
-        await _wireMockAdminApi.ResetRequestsAsync();
-
         var createPath = $"/customs-declarations/{mrn}";
         var mappingBuilder = _wireMockAdminApi.GetMappingBuilder();
         mappingBuilder.Given(m =>
@@ -86,6 +84,37 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
             mrn,
             JsonSerializer.Serialize(finalisation),
             WithInboundHmrcMessageType(InboundHmrcMessageType.Finalisation)
+        );
+
+        Assert.True(
+            await AsyncWaiter.WaitForAsync(async () =>
+            {
+                var requestsModel = new RequestModel { Methods = ["PUT"], Path = createPath };
+                var requests = await _wireMockAdminApi.FindRequestsAsync(requestsModel);
+                return requests.Count == 1;
+            })
+        );
+    }
+
+    [Fact]
+    public async Task WhenInboundErrorSent_TheInboundErrorIsProcessedAndSentToTheDataApi()
+    {
+        var mrn = GenerateMrn();
+        var inboundError = InboundErrorFixture(mrn).Create();
+
+        var createPath = $"/customs-declarations/{mrn}";
+        var mappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        mappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingPut().WithPath(createPath))
+                .WithResponse(rsp => rsp.WithStatusCode(HttpStatusCode.Created))
+        );
+        var status = await mappingBuilder.BuildAndPostAsync();
+        Assert.NotNull(status.Guid);
+
+        await SendMessage(
+            mrn,
+            JsonSerializer.Serialize(inboundError),
+            WithInboundHmrcMessageType(InboundHmrcMessageType.InboundError)
         );
 
         Assert.True(


### PR DESCRIPTION
This adds an integration test for Inbound Errors to simulate pulling an error from the queue, processing it and then saving it via the Data Api.