### PR TITLE
CDMS-476: Enable validation on ClearanceRequest, Finalisation and ServiceHeaders

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           docker compose up -d
           dotnet test tests/Processor.IntegrationTests
+      - name: Docker Compose Logs
+        if: always()
+        run: |
+          docker compose logs
       - name: Check with Trivy
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image trade-imports-processor:latest --ignore-unfixed
   sonarcloud-scan:

--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -147,6 +147,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddValidators(this IServiceCollection services)
     {
         services.AddScoped<IValidator<ClearanceRequestValidatorInput>, ClearanceRequestValidator>();
+        services.AddScoped<IValidator<FinalisationValidatorInput>, FinalisationValidator>();
         services.AddScoped<IValidator<ServiceHeader>, ServiceHeaderValidator>();
 
         return services;

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
@@ -192,7 +192,7 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
                             map.DocumentCode == s.Subject.Document.DocumentCode
                         );
                         return OrEmpty(s.Subject.Commodity.Checks)
-                            .All(check => relevantDocumentChecks.Any(map => map.CheckCode == check.CheckCode));
+                            .Any(check => relevantDocumentChecks.Any(map => map.CheckCode == check.CheckCode));
                     })
                     .WithState(_ => "ALVSVAL320")
                     .WithMessage(
@@ -253,7 +253,7 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
                         var hasIuuCheckCode = checkCodes.Contains("H224");
                         var hasPoaoCheckCode = checkCodes.Contains("H222");
 
-                        return !hasIuuCheckCode || hasPoaoCheckCode;
+                        return (hasIuuCheckCode && hasPoaoCheckCode) || !hasIuuCheckCode;
                     })
                     .WithState(_ => "ALVSVAL328")
                     .WithMessage(

--- a/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
@@ -10,10 +10,8 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
         RuleFor(p => p.NewFinalisation)
             .Must(
                 (p, f) =>
-                    (
-                        f.FinalState != FinalState.CancelledAfterArrival
-                        && f.FinalState != FinalState.CancelledWhilePreLodged
-                    )
+                    f.FinalState != FinalState.CancelledAfterArrival
+                    && f.FinalState != FinalState.CancelledWhilePreLodged
                     && f.ExternalVersion == p.ExistingClearanceRequest.ExternalVersion
             )
             .WithState(_ => "ALVSVAL401")

--- a/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -107,7 +107,7 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
                 .WithResponse(rsp => rsp.WithStatusCode(HttpStatusCode.Created))
         );
         var putMappingBuilderResult = await putMappingBuilder.BuildAndPostAsync();
-        Assert.Null(putMappingBuilderResult);
+        Assert.Null(putMappingBuilderResult.Error);
 
         await SendMessage(
             mrn,

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
@@ -305,6 +305,20 @@ public class ClearanceRequestValidatorTests
                 Checks = [new CommodityCheck { CheckCode = "H218", DepartmentCode = "HMI" }],
                 Documents = [new ImportDocument { DocumentCode = "9115" }],
             },
+            new()
+            {
+                ItemNumber = 4,
+                Checks =
+                [
+                    new CommodityCheck { CheckCode = "H222", DepartmentCode = "PHA" },
+                    new CommodityCheck { CheckCode = "H219", DepartmentCode = "HMI" },
+                ],
+                Documents =
+                [
+                    new ImportDocument { DocumentCode = "9115" },
+                    new ImportDocument { DocumentCode = "N853" },
+                ],
+            },
         };
 
         var newClearanceRequest = DataApiClearanceRequestFixture()
@@ -421,6 +435,7 @@ public class ClearanceRequestValidatorTests
         var commodities = new List<Commodity>
         {
             new() { ItemNumber = 1, Checks = [new CommodityCheck { CheckCode = "H224", DepartmentCode = "PHA" }] },
+            new() { ItemNumber = 2, Checks = [new CommodityCheck { CheckCode = "H222", DepartmentCode = "PHA" }] },
         };
 
         var newClearanceRequest = DataApiClearanceRequestFixture()
@@ -431,10 +446,10 @@ public class ClearanceRequestValidatorTests
             new ClearanceRequestValidatorInput { Mrn = GenerateMrn(), NewClearanceRequest = newClearanceRequest }
         );
 
-        var errors = FindWithErrorCode(result, "ALVSVAL328");
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL328").ToList();
 
-        Assert.NotNull(errors);
-        Assert.Contains("An IUU document has been specified for ItemNumber 1.", errors.ErrorMessage);
+        Assert.Single(errors);
+        Assert.Contains("An IUU document has been specified for ItemNumber 1.", errors[0].ErrorMessage);
     }
 
     [Fact]

--- a/tests/TestFixtures/FinalisationFixtures.cs
+++ b/tests/TestFixtures/FinalisationFixtures.cs
@@ -13,21 +13,20 @@ public static class FinalisationFixtures
         return new Fixture();
     }
 
-    private static FinalisationHeader GenerateHeader(int version, string? mrn)
+    public static IPostprocessComposer<FinalisationHeader> FinalisationHeaderFixture(int version, string? mrn)
     {
         return GetFixture()
             .Build<FinalisationHeader>()
             .With(f => f.FinalState, "0")
             .With(f => f.EntryReference, mrn ?? GenerateMrn())
-            .With(h => h.EntryVersionNumber, version)
-            .Create();
+            .With(h => h.EntryVersionNumber, version);
     }
 
     public static IPostprocessComposer<Finalisation> FinalisationFixture(string? mrn = null, int version = 2)
     {
         return GetFixture()
             .Build<Finalisation>()
-            .With(f => f.Header, GenerateHeader(version, mrn))
+            .With(f => f.Header, FinalisationHeaderFixture(version, mrn).Create())
             .With(f => f.ServiceHeader, ServiceHeaderFixture().Create());
     }
 

--- a/tests/TestFixtures/InboundErrorFixtures.cs
+++ b/tests/TestFixtures/InboundErrorFixtures.cs
@@ -15,7 +15,10 @@ public static class InboundErrorFixtures
 
     public static IPostprocessComposer<InboundError> InboundErrorFixture(string? mrn = null)
     {
-        return GetFixture().Build<InboundError>().With(e => e.Header, HeaderFixture(mrn).Create());
+        return GetFixture()
+            .Build<InboundError>()
+            .With(e => e.Header, HeaderFixture(mrn).Create())
+            .With(e => e.ServiceHeader, ServiceHeaderFixture().Create());
     }
 
     public static IPostprocessComposer<DataApiCustomsDeclaration.InboundError> DataApiInboundErrorFixture()


### PR DESCRIPTION
This enables the validation with the currently implemented validators. At the moment it will just skip the message, which is the intended behaviour, but only logs the errors out and does not send them onwards.

The fixture generation functions required some more explicit configuration to ensure that they were valid for the rules.

A couple of fixes were identified for the validation rules which have been updated.