### PR TITLE
CDMS-476: Add more validation checks and reorganises existing ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+compose-down:
+	docker compose down
+	docker stop processor-asb-backend || true
+	docker stop processor-sqledge || true
+
 dependencies:
 	dotnet tool restore
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   asb-backend:
+    container_name: processor-asb-backend
     environment:
       SQL_WAIT_INTERVAL: 0
       SQL_SERVER: sqledge
@@ -17,6 +18,7 @@ services:
       - "./compose/asb.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
   
   asb:
+    container_name: process-asb
     image: alpine/curl:latest
     depends_on:
       asb-backend:
@@ -33,6 +35,7 @@ services:
     build:
       args:
         DEFRA_NUGET_PAT: ${DEFRA_NUGET_PAT}
+    container_name: processor
     depends_on:
       asb:
         condition: service_healthy
@@ -54,6 +57,7 @@ services:
       - "8080:8080"
   
   sqledge:
+    container_name: processor-sqledge
     healthcheck:
       interval: 5s
       retries: 10
@@ -66,6 +70,7 @@ services:
       MSSQL_SA_PASSWORD: "s4usag3s!"
   
   wiremock:
+    container_name: processor-wiremock
     environment:
       TZ: Europe/London
     image: sheyenrath/wiremock.net:latest
@@ -73,6 +78,7 @@ services:
       - "9090:80"
 
   localstack:
+    container_name: processor-localstack
     image: localstack/localstack
     ports:
       - '4566:4566' # LocalStack Gateway

--- a/compose/asb.json
+++ b/compose/asb.json
@@ -18,7 +18,7 @@
                   "DeadLetteringOnMessageExpiration": false,
                   "DefaultMessageTimeToLive": "PT1H",
                   "LockDuration": "PT1M",
-                  "MaxDeliveryCount": 3,
+                  "MaxDeliveryCount": 1,
                   "ForwardDeadLetteredMessagesTo": "",
                   "ForwardTo": "",
                   "RequiresSession": false

--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -147,8 +147,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddValidators(this IServiceCollection services)
     {
         services.AddScoped<IValidator<ClearanceRequestValidatorInput>, ClearanceRequestValidator>();
+        services.AddScoped<IValidator<CustomsDeclarationsMessage>, CustomsDeclarationsMessageValidator>();
         services.AddScoped<IValidator<FinalisationValidatorInput>, FinalisationValidator>();
-        services.AddScoped<IValidator<ServiceHeader>, ServiceHeaderValidator>();
 
         return services;
     }

--- a/src/Processor/Models/CustomsDeclarations/Header.cs
+++ b/src/Processor/Models/CustomsDeclarations/Header.cs
@@ -8,5 +8,5 @@ public class Header
     public required string EntryReference { get; init; }
 
     [JsonPropertyName("entryVersionNumber")]
-    public required int EntryVersionNumber { get; init; }
+    public int EntryVersionNumber { get; init; }
 }

--- a/src/Processor/Models/CustomsDeclarations/ServiceHeader.cs
+++ b/src/Processor/Models/CustomsDeclarations/ServiceHeader.cs
@@ -6,15 +6,15 @@ namespace Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 public class ServiceHeader
 {
     [JsonPropertyName("sourceSystem")]
-    public required string? SourceSystem { get; set; }
+    public required string SourceSystem { get; init; }
 
     [JsonPropertyName("destinationSystem")]
-    public required string? DestinationSystem { get; set; }
+    public required string DestinationSystem { get; init; }
 
     [JsonPropertyName("correlationId")]
-    public required string CorrelationId { get; set; }
+    public required string CorrelationId { get; init; }
 
     [JsonPropertyName("serviceCallTimestamp")]
     [EpochDateTimeJsonConverter]
-    public required DateTime ServiceCallTimestamp { get; set; }
+    public required DateTime ServiceCallTimestamp { get; init; }
 }

--- a/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
@@ -1,0 +1,20 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class CheckValidator : AbstractValidator<CommodityCheck>
+{
+    public CheckValidator(int itemNumber, string correlationId)
+    {
+        RuleFor(p => p.CheckCode)
+            .NotEmpty()
+            .WithMessage(_ =>
+                $"The CheckCode field on item number {itemNumber} must have a value. Your service request with Correlation ID {correlationId} has been terminated."
+            )
+            .WithState(_ => "ALVSVAL311");
+
+        RuleFor(p => p.CheckCode).MaximumLength(4);
+        RuleFor(p => p.DepartmentCode).NotEmpty().MaximumLength(8);
+    }
+}

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
@@ -1,69 +1,39 @@
-using System.Collections.Frozen;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using FluentValidation;
-using ClearanceRequest = Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ClearanceRequest;
+using DataApiCustomsDeclaration = Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Finalisation = Defra.TradeImportsDataApi.Domain.CustomsDeclaration.Finalisation;
 
 namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
 
 public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValidatorInput>
 {
-    public readonly List<CommodityDocumentCheckMap> CommodityDocumentCheckMap =
-    [
-        new() { CheckCode = "H221", DocumentCode = "C640" },
-        new() { CheckCode = "H223", DocumentCode = "C678" },
-        new() { CheckCode = "H222", DocumentCode = "N853" },
-        new() { CheckCode = "H224", DocumentCode = "C673" },
-        new() { CheckCode = "H219", DocumentCode = "N851" },
-        new() { CheckCode = "H219", DocumentCode = "9115" },
-        new() { CheckCode = "H219", DocumentCode = "C085" },
-        new() { CheckCode = "H218", DocumentCode = "N002" },
-        new() { CheckCode = "H218", DocumentCode = "C085" },
-        new() { CheckCode = "H218", DocumentCode = "9HCG" },
-        new() { CheckCode = "H220", DocumentCode = "N002" },
-        new() { CheckCode = "H220", DocumentCode = "9HCG" },
-    ];
-
-    private static IEnumerable<T> OrEmpty<T>(IEnumerable<T>? items)
-    {
-        return items ?? [];
-    }
-
-    private static IEnumerable<ClearanceRequestValidatorInputSubject<T>> WithSubject<T>(
-        ClearanceRequestValidatorInput input,
-        IEnumerable<T> subjects
-    )
-    {
-        return subjects.Select(subject => new ClearanceRequestValidatorInputSubject<T>
-        {
-            NewClearanceRequest = input.NewClearanceRequest,
-            ExistingClearanceRequest = input.ExistingClearanceRequest,
-            ExistingFinalisation = input.ExistingFinalisation,
-            Mrn = input.Mrn,
-            Subject = subject,
-        });
-    }
-
     public ClearanceRequestValidator()
     {
-        var validDocumentCodes = CommodityDocumentCheckMap.Select(c => c.DocumentCode).Distinct().ToList();
+        RuleFor(p => p.NewClearanceRequest.PreviousExternalVersion)
+            .NotNull()
+            .WithState(_ => "ALVSVAL152")
+            .WithMessage(p =>
+                $"PreviousVersionNumber has not been provided for the import document. Provide a PreviousVersionNumber. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
+            )
+            .When(p => p.NewClearanceRequest.ExternalVersion > 1);
+
+        RuleFor(p => p)
+            .Must(p => p.NewClearanceRequest.ExternalVersion > p.NewClearanceRequest.PreviousExternalVersion)
+            .WithState(_ => "ALVSVAL326")
+            .WithMessage(p =>
+                $"The previous version number {p.NewClearanceRequest.PreviousExternalVersion} on the entry document must be less than the entry version number. Your service request with Correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
+            )
+            .When(p => p.NewClearanceRequest.PreviousExternalVersion.HasValue);
+
+        RuleFor(p => p.NewClearanceRequest.DeclarationUcr).MaximumLength(35);
+        RuleFor(p => p.NewClearanceRequest.DeclarantId).NotEmpty().MaximumLength(18);
+        RuleFor(p => p.NewClearanceRequest.DeclarantName).NotEmpty().MaximumLength(35);
+        RuleFor(p => p.NewClearanceRequest.DispatchCountryCode).NotEmpty().Length(2);
+        RuleFor(p => p.NewClearanceRequest.DeclarationType).Must(p => p is "S" or "F");
 
         RuleForEach(p => p.NewClearanceRequest.Commodities)
-            .Must(commodity => HaveAValidCommodityDecimalFormat(commodity.SupplementaryUnits))
-            .WithState(_ => "ALVSVAL108")
-            .WithMessage(
-                (p, c) =>
-                    $"Supplementary units format on item number {c.ItemNumber} is invalid. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated. Enter it in the format 99999999999.999."
-            );
-
-        RuleForEach(p => p.NewClearanceRequest.Commodities)
-            .Must(commodity => HaveAValidCommodityDecimalFormat(commodity.NetMass))
-            .WithState(_ => "ALVSVAL109")
-            .WithMessage(
-                (p, c) =>
-                    $"Net mass format on item number {c.ItemNumber} is invalid. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated. Enter it in the format 99999999999.999."
-            );
+            .SetValidator(p => new CommodityValidator(p.NewClearanceRequest.ExternalCorrelationId!));
 
         When(
             p => p.NewClearanceRequest.ExternalVersion != 1,
@@ -109,118 +79,12 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
             }
         );
 
-        RuleForEach(p =>
-                WithSubject(
-                    p,
-                    OrEmpty(p.NewClearanceRequest.Commodities)
-                        .Select(c =>
-                            OrEmpty(c.Documents)
-                                .Select(doc => new DocumentByCommodity { Commodity = c, Document = doc })
-                        )
-                        .SelectMany(x => x)
-                )
-            )
-            .Must(c =>
-                c.Subject.Document.DocumentCode != null && validDocumentCodes.Contains(c.Subject.Document.DocumentCode)
-            )
-            .OverridePropertyName("DocumentCode")
-            .WithState(_ => "ALVSVAL308")
-            .WithMessage(
-                (_, c) =>
-                    $"DocumentCode {c.Subject.Document.DocumentCode} on item number {c.Subject.Commodity.ItemNumber} is invalid. Your request with correlation ID {c.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-            );
-
-        RuleForEach(p => p.NewClearanceRequest.Commodities)
-            .Must(commodity => (commodity.Checks ?? []).Any(check => check.CheckCode != null))
-            .WithState(_ => "ALVSVAL311")
-            .WithMessage(
-                (p, c) =>
-                    $"The CheckCode field on item number {c.ItemNumber} must have a value. Your service request with Correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-            );
-
         RuleFor(p => p.NewClearanceRequest.DeclarationUcr)
             .NotNull()
             .WithState(_ => "ALVSVAL313")
             .WithMessage(p =>
                 $"The DeclarationUCR field must have a value.  Your service request with Correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
             );
-
-        RuleFor(p => WithSubject(p, p.NewClearanceRequest.Commodities ?? Array.Empty<Commodity>()))
-            .ForEach(p =>
-            {
-                p.Must(s =>
-                    {
-                        var hasMoreThanOneDepartmentCheck = (s.Subject.Checks ?? [])
-                            .GroupBy(check => check.DepartmentCode)
-                            .Any(g => g.Count() > 1);
-                        return !hasMoreThanOneDepartmentCheck;
-                    })
-                    .WithState(_ => "ALVSVAL317")
-                    .WithMessage(
-                        (_, s) =>
-                            $"Item {s.Subject.ItemNumber} has more than one Item Check defined for the same authority. You can only provide one. Your service request with Correlation ID {s.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            });
-
-        RuleFor(p => WithSubject(p, OrEmpty(p.NewClearanceRequest.Commodities)))
-            .ForEach(p =>
-            {
-                p.Must(s => s.Subject.Documents?.Length > 0)
-                    .WithState(_ => "ALVSVAL318")
-                    .WithMessage(
-                        (_, s) =>
-                            $"Item {s.Subject.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {s.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            });
-
-        RuleFor(p =>
-                WithSubject(
-                    p,
-                    OrEmpty(p.NewClearanceRequest.Commodities)
-                        .Select(commodity =>
-                            OrEmpty(commodity.Documents)
-                                .Select(doc => new DocumentByCommodity { Commodity = commodity, Document = doc })
-                        )
-                        .SelectMany(x => x)
-                )
-            )
-            .ForEach(p =>
-            {
-                p.Must(s =>
-                    {
-                        var relevantDocumentChecks = CommodityDocumentCheckMap.Where(map =>
-                            map.DocumentCode == s.Subject.Document.DocumentCode
-                        );
-                        return OrEmpty(s.Subject.Commodity.Checks)
-                            .Any(check => relevantDocumentChecks.Any(map => map.CheckCode == check.CheckCode));
-                    })
-                    .WithState(_ => "ALVSVAL320")
-                    .WithMessage(
-                        (_, d) =>
-                            $"Document code {d.Subject.Document.DocumentCode} is not appropriate for the check code requested on ItemNumber {d.Subject.Commodity.ItemNumber}. Your request with correlation ID {d.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            });
-
-        RuleFor(p =>
-                WithSubject(
-                    p,
-                    OrEmpty(p.NewClearanceRequest.Commodities)
-                        .Select(commodity =>
-                            OrEmpty(commodity.Checks)
-                                .Select(check => new CheckByCommodity { Check = check, Commodity = commodity })
-                        )
-                        .SelectMany(x => x)
-                )
-            )
-            .ForEach(p =>
-            {
-                p.Must(s => OrEmpty(s.Subject.Commodity.Documents).Any())
-                    .WithState(_ => "ALVSVAL321")
-                    .WithMessage(
-                        (_, d) =>
-                            $"Check code {d.Subject.Check.CheckCode} on ItemNumber {d.Subject.Commodity.ItemNumber} must have a document code. Your request with Correlation ID {d.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            });
 
         When(
             p => p.ExistingFinalisation is not null,
@@ -243,29 +107,11 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
                 (_, p) =>
                     $"The previous version number {p.PreviousExternalVersion} on the entry document must be less than the entry version number. Your service request with Correlation ID {p.ExternalCorrelationId} has been terminated."
             );
-
-        RuleFor(p => WithSubject(p, OrEmpty(p.NewClearanceRequest.Commodities)))
-            .ForEach(p =>
-            {
-                p.Must(c =>
-                    {
-                        var checkCodes = (c.Subject.Checks ?? []).Select(check => check.CheckCode).ToList();
-                        var hasIuuCheckCode = checkCodes.Contains("H224");
-                        var hasPoaoCheckCode = checkCodes.Contains("H222");
-
-                        return (hasIuuCheckCode && hasPoaoCheckCode) || !hasIuuCheckCode;
-                    })
-                    .WithState(_ => "ALVSVAL328")
-                    .WithMessage(
-                        (_, cvc) =>
-                            $"An IUU document has been specified for ItemNumber {cvc.Subject.ItemNumber}. Request a manual clearance if the item does not require a CHED P. Your request with correlation ID {cvc.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            });
     }
 
     private static bool NotBeADuplicateEntryVersionNumber(
-        ClearanceRequest newClearanceRequest,
-        ClearanceRequest? existingClearanceRequest
+        DataApiCustomsDeclaration.ClearanceRequest newClearanceRequest,
+        DataApiCustomsDeclaration.ClearanceRequest? existingClearanceRequest
     )
     {
         return newClearanceRequest.ExternalVersion != existingClearanceRequest?.ExternalVersion;
@@ -274,13 +120,5 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
     private static bool NotBeCancelled(Finalisation? existingFinalisation)
     {
         return !existingFinalisation?.FinalState.IsCancelled() ?? true;
-    }
-
-    private static bool HaveAValidCommodityDecimalFormat(decimal? value)
-    {
-        var supplementaryUnits = value.ToString() ?? "";
-        var length = supplementaryUnits.Replace(".", "").Length;
-        var numDecimals = supplementaryUnits.SkipWhile(c => c != '.').Skip(1).Count();
-        return length <= 14 && numDecimals <= 3;
     }
 }

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidatorInput.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidatorInput.cs
@@ -4,8 +4,8 @@ namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
 
 public record ClearanceRequestValidatorInput
 {
-    public required string Mrn { get; init; }
     public required ClearanceRequest NewClearanceRequest { get; init; }
     public ClearanceRequest? ExistingClearanceRequest { get; init; }
     public Finalisation? ExistingFinalisation { get; init; }
+    public required string Mrn { get; init; }
 }

--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -1,0 +1,145 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class CommodityValidator : AbstractValidator<Commodity>
+{
+    public CommodityValidator(string correlationId)
+    {
+        RuleFor(p => p.ItemNumber).NotNull().InclusiveBetween(1, 999);
+        RuleFor(p => p.CustomsProcedureCode).NotEmpty().MaximumLength(7);
+        RuleFor(p => p.TaricCommodityCode).NotEmpty().Matches("\\d").Length(10);
+        RuleFor(p => p.GoodsDescription).NotEmpty().MaximumLength(280);
+
+        RuleFor(p => p.ConsigneeId).NotEmpty().MaximumLength(18);
+        RuleFor(p => p.ConsigneeName).NotEmpty().MaximumLength(35);
+        RuleFor(p => p.NetMass).NotNull();
+        RuleFor(p => p.OriginCountryCode).NotNull().Length(2);
+
+        RuleForEach(p => p.Documents)
+            .SetValidator(item => new ImportDocumentValidator((int)item.ItemNumber!, correlationId));
+        RuleForEach(p => p.Checks).SetValidator(item => new CheckValidator((int)item.ItemNumber!, correlationId));
+
+        RuleFor(p => p.SupplementaryUnits)
+            .Must(HaveAValidCommodityDecimalFormat)
+            .WithState(_ => "ALVSVAL108")
+            .WithMessage(p =>
+                $"Supplementary units format on item number {p.ItemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated. Enter it in the format 99999999999.999."
+            );
+
+        RuleFor(p => p.NetMass)
+            .Must(HaveAValidCommodityDecimalFormat)
+            .WithState(_ => "ALVSVAL109")
+            .WithMessage(p =>
+                $"Net mass format on item number {p.ItemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated. Enter it in the format 99999999999.999."
+            );
+
+        RuleFor(p => p.Documents)
+            .NotEmpty()
+            .WithState(_ => "ALVSVAL318")
+            .WithMessage(p =>
+                $"Item {p.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated."
+            );
+
+        RuleForEach(p => p.Documents)
+            .Must(MustHaveCorrectDocumentCodesForChecks)
+            .WithMessage(
+                (item, document) =>
+                    $"Document code {document.DocumentCode} is not appropriate for the check code requested on ItemNumber {item.ItemNumber}. Your request with correlation ID {correlationId} has been terminated."
+            )
+            .WithState(_ => "ALVSVAL320")
+            .When(p => p.Checks is not null);
+
+        RuleForEach(p => p.Checks)
+            .Must(MustHaveDocumentForCheck)
+            .WithMessage(
+                (item, check) =>
+                    $"Check code {check.CheckCode} on ItemNumber {item.ItemNumber} must have a document code. Your request with Correlation ID {correlationId} has been terminated."
+            )
+            .WithState(_ => "ALVSVAL321");
+
+        RuleFor(p => p.Checks)
+            .Must(MustOnlyHaveOneCheckPerAuthority!)
+            .WithMessage(p =>
+                $"Item {p.ItemNumber} has more than one Item Check defined for the same authority. You can only provide one. Your service request with Correlation ID {correlationId} has been terminated."
+            )
+            .WithState(_ => "ALVSVAL317")
+            .When(p => p.Checks is not null);
+
+        RuleFor(p => p.Checks)
+            .Must(MustHavePoAoCheck!)
+            .WithMessage(p =>
+                $"An IUU document has been specified for ItemNumber {p.ItemNumber}. Request a manual clearance if the item does not require a CHED P. Your request with correlation ID {correlationId} has been terminated."
+            )
+            .WithState(_ => "ALVSVAL328")
+            .When(x => x.Checks is not null && x.Checks.Any(y => y.CheckCode == "H224"));
+
+        RuleFor(p => p.Documents)
+            .NotEmpty()
+            .WithMessage(c =>
+                $"Item {c.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated.."
+            )
+            .WithState(_ => "ALVSVAL308");
+    }
+
+    private static bool MustHaveCorrectDocumentCodesForChecks(Commodity commodity, ImportDocument importDocument)
+    {
+        var checkCodes = AuthorityCodeMappings
+            .Where(x => x.DocumentCode == importDocument.DocumentCode)
+            .Select(x => x.CheckCode);
+        return commodity.Checks != null && commodity.Checks.Any(x => checkCodes.Contains(x.CheckCode));
+    }
+
+    private static bool MustHaveDocumentForCheck(Commodity commodity, CommodityCheck check)
+    {
+        var documentCodes = AuthorityCodeMappings
+            .Where(x => x.CheckCode == check.CheckCode)
+            .Select(x => x.DocumentCode);
+        return commodity.Documents != null && commodity.Documents.Any(x => documentCodes.Contains(x.DocumentCode));
+    }
+
+    private static bool HaveAValidCommodityDecimalFormat(Commodity commodity, decimal? value)
+    {
+        var supplementaryUnits = value.ToString() ?? "";
+        var length = supplementaryUnits.Replace(".", "").Length;
+        var numDecimals = supplementaryUnits.SkipWhile(c => c != '.').Skip(1).Count();
+        return length <= 14 && numDecimals <= 3;
+    }
+
+    private static bool MustOnlyHaveOneCheckPerAuthority(Commodity commodity, CommodityCheck[] checks)
+    {
+        var checkCodes = checks.Select(x => x.CheckCode);
+
+        var authorityCheckCodeMatches = AuthorityCodeMappings
+            .DistinctBy(a => a.CheckCode)
+            .Where(a => checkCodes.Contains(a.CheckCode))
+            .GroupBy(a => a.Name);
+
+        return authorityCheckCodeMatches.All(a => a.Count() <= 1);
+    }
+
+    private static bool MustHavePoAoCheck(Commodity commodity, CommodityCheck[] checks)
+    {
+        return checks.Any(x => x.CheckCode == "H222");
+    }
+
+    public sealed record AuthorityCodeMap(string Name, string DocumentCode, string CheckCode);
+
+    public static readonly List<AuthorityCodeMap> AuthorityCodeMappings =
+    [
+        new("hmi", "N002", "H218"),
+        new("hmi", "N002", "H220"),
+        new("hmi", "C085", "H218"),
+        new("hmi", "C085", "H220"),
+        new("phsi", "N851", "H219"),
+        new("phsi", "9115", "H219"),
+        new("phsi", "C085", "H219"),
+        new("pha", "C673", "H224"),
+        new("pha", "C641", "H224"),
+        new("pha", "N853", "H222"),
+        new("pha", "C678", "H223"),
+        new("apha", "C640", "H221"),
+    ];
+}

--- a/src/Processor/Validation/CustomsDeclarations/CustomsDeclarationsMessageValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CustomsDeclarationsMessageValidator.cs
@@ -1,0 +1,13 @@
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class CustomsDeclarationsMessageValidator : AbstractValidator<CustomsDeclarationsMessage>
+{
+    public CustomsDeclarationsMessageValidator()
+    {
+        RuleFor(p => p.ServiceHeader).SetValidator(new ServiceHeaderValidator());
+        RuleFor(p => p.Header).SetValidator(p => new HeaderValidator(p.ServiceHeader.CorrelationId));
+    }
+}

--- a/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
@@ -7,64 +7,78 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
 {
     public FinalisationValidator()
     {
-        RuleFor(p => p.NewFinalisation)
-            .Must(
-                (p, f) =>
-                    f.FinalState != FinalState.CancelledAfterArrival
-                    && f.FinalState != FinalState.CancelledWhilePreLodged
-                    && f.ExternalVersion == p.ExistingClearanceRequest.ExternalVersion
-            )
+        RuleFor(p => p.NewFinalisation.ExternalVersion).NotNull().InclusiveBetween(1, 99);
+
+        RuleFor(p => p.Mrn)
+            .NotEmpty()
+            .MaximumLength(22)
+            .Matches("[1-9]{2}[A-Za-z]{2}[A-Za-z0-9]{14}")
+            .WithState(_ => "ALVSVAL401");
+
+        RuleFor(p => p.NewFinalisation.FinalState)
+            .Must(BeANewFinalisation)
             .WithState(_ => "ALVSVAL401")
-            .WithMessage(
-                (p, f) =>
-                    $"The finalised state was received for EntryReference {p.Mrn} EntryVersionNumber {f.ExternalVersion}. This has already been replaced by a later version of the import declaration. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+            .WithMessage(p =>
+                $"The finalised state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion}. This has already been replaced by a later version of the import declaration. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
 
         RuleFor(p => p.NewFinalisation)
-            .Must((p, f) => Enum.IsDefined(f.FinalState))
+            .Must((_, f) => Enum.IsDefined(f.FinalState))
             .WithState(_ => "ALVSVAL402")
             .WithMessage(
                 (p, f) =>
                     $"The FinalState {f.FinalState} is invalid. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
 
-        RuleFor(p => p.NewFinalisation)
-            .Must(
-                (p, f) =>
-                    p.ExistingFinalisation?.FinalState != FinalState.CancelledAfterArrival
-                    && p.ExistingFinalisation?.FinalState != FinalState.CancelledWhilePreLodged
-            )
+        RuleFor(p => p.NewFinalisation.FinalState)
+            .Must(NotBeAlreadyCancelled)
             .WithState(_ => "ALVSVAL403")
-            .WithMessage(
-                (p, f) =>
-                    $"The final state was received for EntryReference {p.Mrn} EntryVersionNumber {f.ExternalVersion} but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+            .WithMessage(p =>
+                $"The final state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
 
-        RuleFor(p => p.NewFinalisation)
-            .Must(
-                (p, f) =>
-                    p.ExistingFinalisation?.FinalState != FinalState.CancelledAfterArrival
-                    && p.ExistingFinalisation?.FinalState != FinalState.CancelledWhilePreLodged
-                    && f.FinalState != FinalState.CancelledAfterArrival
-                    && f.FinalState != FinalState.CancelledWhilePreLodged
-            )
-            .WithState(_ => "ALVSVAL404")
-            .WithMessage(
-                (p, f) =>
-                    $"An attempt to cancel EntryReference {p.Mrn} EntryVersionNumber {f.ExternalVersion} was made but the import declaration was cancelled. Your request with correlation ID {f.ExternalCorrelationId} has been terminated."
+        RuleFor(p => p.NewFinalisation.FinalState)
+            .Must(NotBeACancellationWhenAlreadyCancelled)
+            .WithState(_ => "ALVSVAL501")
+            .WithMessage(p =>
+                $"An attempt to cancel EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} was made but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
 
-        RuleFor(p => p.NewFinalisation)
-            .Must(
-                (p, f) =>
-                    f.FinalState != FinalState.CancelledAfterArrival
-                    && f.FinalState != FinalState.CancelledWhilePreLodged
-                    && p.ExistingClearanceRequest.ExternalVersion == f.ExternalVersion
-            )
-            .WithState(_ => "ALVSVAL405")
-            .WithMessage(
-                (p, f) =>
-                    $"The import declaration was received as a cancellation. The EntryReference {p.Mrn} EntryVersionNumber {f.ExternalVersion} have already been replaced by a later version. Your request with correlation ID {f.ExternalCorrelationId} has been terminated."
+        RuleFor(p => p.NewFinalisation.FinalState)
+            .Must(BeAValidCancellationRequest)
+            .WithState(_ => "ALVSVAL506")
+            .WithMessage(p =>
+                $"The import declaration was received as a cancellation. The EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} have already been replaced by a later version. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
+    }
+
+    private static bool BeANewFinalisation(FinalisationValidatorInput p, FinalState finalState)
+    {
+        return finalState is not (FinalState.CancelledAfterArrival or FinalState.CancelledWhilePreLodged)
+            && p.NewFinalisation.ExternalVersion == p.ExistingClearanceRequest.ExternalVersion;
+    }
+
+    private static bool NotBeAlreadyCancelled(FinalisationValidatorInput p, FinalState finalState)
+    {
+        return p.ExistingFinalisation?.FinalState != FinalState.CancelledAfterArrival
+            && p.ExistingFinalisation?.FinalState != FinalState.CancelledWhilePreLodged;
+    }
+
+    private static bool NotBeACancellationWhenAlreadyCancelled(FinalisationValidatorInput p, FinalState finalState)
+    {
+        var alreadyCancelled =
+            p.ExistingFinalisation?.FinalState
+                is FinalState.CancelledAfterArrival
+                    or FinalState.CancelledWhilePreLodged;
+        var willCancel = finalState is FinalState.CancelledAfterArrival or FinalState.CancelledWhilePreLodged;
+
+        return !alreadyCancelled && !willCancel;
+    }
+
+    private static bool BeAValidCancellationRequest(FinalisationValidatorInput p, FinalState finalState)
+    {
+        var isCancellation = finalState is FinalState.CancelledAfterArrival or FinalState.CancelledWhilePreLodged;
+
+        return !isCancellation || p.ExistingClearanceRequest.ExternalVersion == p.NewFinalisation.ExternalVersion;
     }
 }

--- a/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
@@ -1,0 +1,25 @@
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class HeaderValidator : AbstractValidator<Header>
+{
+    public HeaderValidator(string correlationId)
+    {
+        RuleFor(p => p.EntryReference)
+            .NotEmpty()
+            .MaximumLength(22)
+            .Matches("[1-9]{2}[A-Za-z]{2}[A-Za-z0-9]{14}")
+            .WithState(p => "ALVSVAL303");
+
+        RuleFor(p => p.EntryVersionNumber)
+            .NotNull()
+            .WithState(p => "ALVSVAL153")
+            .WithMessage(p =>
+                $"EntryVersionNumber has not been provided for the import document. Provide an EntryVersionNumber. Your request with correlation ID {correlationId} has been terminated."
+            );
+
+        RuleFor(p => p.EntryVersionNumber).InclusiveBetween(1, 99);
+    }
+}

--- a/src/Processor/Validation/CustomsDeclarations/HeaderValidatorInput.cs
+++ b/src/Processor/Validation/CustomsDeclarations/HeaderValidatorInput.cs
@@ -1,0 +1,9 @@
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public record HeaderValidatorInput
+{
+    public required Header Header { get; init; }
+    public required ServiceHeader ServiceHeader { get; init; }
+};

--- a/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
@@ -1,0 +1,42 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class ImportDocumentValidator : AbstractValidator<ImportDocument>
+{
+    public ImportDocumentValidator(int itemNumber, string correlationId)
+    {
+        RuleFor(p => p.DocumentCode)
+            .Must(BeAValidDocumentCode!)
+            .WithMessage(c =>
+                $"DocumentCode {c.DocumentCode} on item number {itemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated."
+            )
+            .WithState(p => "ALVSVAL308");
+
+        RuleFor(p => p.DocumentStatus).NotEmpty().MaximumLength(2);
+
+        RuleFor(p => p.DocumentControl).NotEmpty().MaximumLength(1);
+    }
+
+    private static readonly List<string> s_documentCodes =
+    [
+        "C085",
+        "C633",
+        "C640",
+        "C641",
+        "C673",
+        "N002",
+        "N851",
+        "N852",
+        "C678",
+        "N853",
+        "9HCG",
+        "9115",
+    ];
+
+    private static bool BeAValidDocumentCode(string documentCode)
+    {
+        return !string.IsNullOrEmpty(documentCode) && s_documentCodes.Contains(documentCode);
+    }
+}

--- a/tests/Processor.IntegrationTests/Helpers/AsyncWaiter.cs
+++ b/tests/Processor.IntegrationTests/Helpers/AsyncWaiter.cs
@@ -5,18 +5,18 @@ namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Helpers;
 public static class AsyncWaiter
 {
     private static readonly TimeSpan s_defaultDelay = TimeSpan.FromSeconds(2);
-    private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds(30);
 
-    public static async Task<bool> WaitForAsync(Func<Task<bool>> condition)
+    public static async Task<bool> WaitForAsync(Func<Task<bool>> condition, double? timeout = null)
     {
         var timer = Stopwatch.StartNew();
+        var timeoutTimespan = TimeSpan.FromSeconds(timeout ?? 30);
 
         while (true)
         {
             if (await condition())
                 return true;
 
-            if (timer.Elapsed > s_defaultTimeout)
+            if (timer.Elapsed > timeoutTimespan)
                 return false;
 
             await Task.Delay(s_defaultDelay);

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CheckValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CheckValidatorTests.cs
@@ -1,0 +1,62 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using FluentValidation.TestHelper;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class CheckValidatorTests
+{
+    private readonly CheckValidator _validator = new(1, "123");
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL311_WhenACommodityCheckHasNoCheckCode()
+    {
+        var check = new CommodityCheck();
+
+        var result = _validator.TestValidate(check);
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL311");
+
+        Assert.NotNull(error);
+        Assert.Contains("The CheckCode field on item number 1 must have a value.", error.ErrorMessage);
+    }
+
+    [Theory, ClassData(typeof(CheckValidatorTestData))]
+    public void TheoryTests(CommodityCheck check, ExpectedResult expectedResult)
+    {
+        var result = _validator.TestValidate(check);
+
+        if (expectedResult.HasValidationError)
+        {
+            result.ShouldHaveValidationErrorFor(expectedResult.PropertyName);
+            return;
+        }
+
+        result.ShouldNotHaveValidationErrorFor(expectedResult.PropertyName);
+    }
+
+    public class CheckValidatorTestData : TheoryData<CommodityCheck, ExpectedResult>
+    {
+        public CheckValidatorTestData()
+        {
+            Add(
+                new CommodityCheck { DepartmentCode = "test" },
+                new ExpectedResult(nameof(CommodityCheck.DepartmentCode), false)
+            );
+            Add(
+                new CommodityCheck { DepartmentCode = "qwertyuip" },
+                new ExpectedResult(nameof(CommodityCheck.DepartmentCode), true)
+            );
+            Add(
+                new CommodityCheck { DepartmentCode = null },
+                new ExpectedResult(nameof(CommodityCheck.DepartmentCode), true)
+            );
+
+            Add(new CommodityCheck { CheckCode = "test" }, new ExpectedResult(nameof(CommodityCheck.CheckCode), false));
+            Add(
+                new CommodityCheck { CheckCode = "qwerty" },
+                new ExpectedResult(nameof(CommodityCheck.CheckCode), true)
+            );
+            Add(new CommodityCheck { CheckCode = null }, new ExpectedResult(nameof(CommodityCheck.CheckCode), true));
+        }
+    }
+}

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -1,0 +1,166 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using FluentValidation.TestHelper;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class CommodityValidatorTests
+{
+    private readonly CommodityValidator _validator = new("123");
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(99999999999.999, false)]
+    [InlineData(999999999999.999, true)]
+    [InlineData(9999999999.9999, true)]
+    public void Validate_Returns_ALVSVAL108_WhenCommodityQuantityIsInvalid(decimal supplementaryUnits, bool shouldError)
+    {
+        var commodity = new Commodity { ItemNumber = 1, SupplementaryUnits = supplementaryUnits };
+
+        var result = _validator.TestValidate(commodity);
+
+        if (shouldError)
+        {
+            result.ShouldHaveValidationErrorFor(c => c.SupplementaryUnits);
+            var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL108");
+            Assert.NotNull(error);
+            Assert.Contains("Supplementary units format on item number 1 is invalid.", error.ErrorMessage);
+            return;
+        }
+
+        result.ShouldNotHaveValidationErrorFor(c => c.SupplementaryUnits);
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(99999999999.999, false)]
+    [InlineData(999999999999.999, true)]
+    [InlineData(9999999999.9999, true)]
+    public void Validate_Returns_ALVSVAL109_WhenCommodityNetMassIsInvalid(decimal netMass, bool shouldError)
+    {
+        var commodity = new Commodity { ItemNumber = 1, NetMass = netMass };
+
+        var result = _validator.TestValidate(commodity);
+
+        if (shouldError)
+        {
+            result.ShouldHaveValidationErrorFor(c => c.NetMass);
+            var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL109");
+            Assert.NotNull(error);
+            Assert.Contains("Net mass format on item number 1 is invalid.", error.ErrorMessage);
+            return;
+        }
+
+        result.ShouldNotHaveValidationErrorFor(c => c.NetMass);
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL317_WhenTwoChecksByTheSameAuthorityAreOnTheSameCommodity()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 1,
+            Checks =
+            [
+                new CommodityCheck { CheckCode = "H218", DepartmentCode = "HMI" },
+                new CommodityCheck { CheckCode = "H220", DepartmentCode = "HMI" },
+            ],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL317");
+
+        Assert.NotNull(error);
+        Assert.Contains("Item 1 has more than one Item Check defined for the same authority.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL318_WhenADocumentIsNotProvidedForCommodity()
+    {
+        var commodity = new Commodity { ItemNumber = 1 };
+
+        var result = _validator.TestValidate(commodity);
+        result.ShouldHaveValidationErrorFor(c => c.Documents);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL318");
+
+        Assert.NotNull(error);
+        Assert.Contains("Item 1 has no document code.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL320_WhenTheCheckCodesSpecified_ButAreNotRelevantToTheDocumentCodes()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 1,
+            Checks = [new CommodityCheck { CheckCode = "H222", DepartmentCode = "PHA" }],
+            Documents = [new ImportDocument { DocumentCode = "C640" }],
+        };
+
+        var result = _validator.TestValidate(commodity);
+        result.ShouldHaveValidationErrorFor(c => c.Checks);
+
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL320").ToList();
+
+        Assert.Contains(
+            "Document code C640 is not appropriate for the check code requested on ItemNumber 1",
+            errors[0].ErrorMessage
+        );
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL321_WhenCheckCodesAreSpecified_ButNoDocumentCodesAreSpecified()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 2,
+            Checks = [new CommodityCheck { CheckCode = "H222", DepartmentCode = "PHA" }],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL321").ToList();
+
+        Assert.Single(errors);
+        Assert.Contains("Check code H222 on ItemNumber 2 must have a document code.", errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL328_WhenAnIuuCheckIsSpecifiedButHasNoPoaoCheck()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 1,
+            Checks = [new CommodityCheck { CheckCode = "H224", DepartmentCode = "PHA" }],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL328").ToList();
+
+        Assert.Single(errors);
+        Assert.Contains("An IUU document has been specified for ItemNumber 1.", errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_DoesNotReturn_ALVSVAL328_WhenIuuCheckANdPoaoCheckIsSpecified()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 1,
+            Checks =
+            [
+                new CommodityCheck { CheckCode = "H222", DepartmentCode = "PHA" },
+                new CommodityCheck { CheckCode = "H224", DepartmentCode = "PHA" },
+            ],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL328").ToList();
+
+        Assert.Empty(errors);
+    }
+}

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CustomsDeclarationsMessageValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CustomsDeclarationsMessageValidatorTests.cs
@@ -1,0 +1,74 @@
+using AutoFixture;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using Elastic.CommonSchema;
+using FluentValidation.TestHelper;
+using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class CustomsDeclarationsMessageValidatorTests
+{
+    private readonly CustomsDeclarationsMessageValidator _validator = new();
+
+    [Theory, ClassData(typeof(CustomsDeclarationsMessageValidatorTestData))]
+    public void TheoryTests(CustomsDeclarationsMessage customsDeclarationsMessage, ExpectedResult expectedResult)
+    {
+        var result = _validator.TestValidate(customsDeclarationsMessage);
+
+        if (expectedResult.HasValidationError)
+        {
+            result.ShouldHaveValidationErrorFor(expectedResult.PropertyName);
+            return;
+        }
+
+        result.ShouldNotHaveValidationErrorFor(expectedResult.PropertyName);
+    }
+
+    public class CustomsDeclarationsMessageValidatorTestData : TheoryData<CustomsDeclarationsMessage, ExpectedResult>
+    {
+        public CustomsDeclarationsMessageValidatorTestData()
+        {
+            Add(
+                new CustomsDeclarationsMessage
+                {
+                    Header = new Header { EntryReference = "15GB1245fst7s8g9s4" },
+                    ServiceHeader = ServiceHeaderFixture().Create(),
+                },
+                new ExpectedResult("Header.EntryReference", false)
+            );
+            Add(
+                new CustomsDeclarationsMessage
+                {
+                    Header = new Header { EntryReference = "invalid" },
+                    ServiceHeader = ServiceHeaderFixture().Create(),
+                },
+                new ExpectedResult("Header.EntryReference", true)
+            );
+            Add(
+                new CustomsDeclarationsMessage
+                {
+                    Header = new Header { EntryReference = "15GB1245fst7s8g9s4", EntryVersionNumber = 2 },
+                    ServiceHeader = ServiceHeaderFixture().Create(),
+                },
+                new ExpectedResult("Header.EntryVersionNumber", false)
+            );
+            Add(
+                new CustomsDeclarationsMessage
+                {
+                    Header = new Header { EntryReference = "15GB1245fst7s8g9s4", EntryVersionNumber = -1 },
+                    ServiceHeader = ServiceHeaderFixture().Create(),
+                },
+                new ExpectedResult("Header.EntryVersionNumber", true)
+            );
+            Add(
+                new CustomsDeclarationsMessage
+                {
+                    Header = new Header { EntryReference = "15GB1245fst7s8g9s4", EntryVersionNumber = 100 },
+                    ServiceHeader = ServiceHeaderFixture().Create(),
+                },
+                new ExpectedResult("Header.EntryVersionNumber", true)
+            );
+        }
+    }
+}

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ExpectedResult.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ExpectedResult.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public record ExpectedResult(string PropertyName, bool HasValidationError);

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
 using FluentValidation.Results;
 using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
@@ -100,15 +101,14 @@ public class FinalisationValidatorTests
     }
 
     [Fact]
-    public void Validate_Returns_ALVSVAL404_WhenANewFinalisationAttemptsToCancelAnImportButItHasAlreadyBeenCancelled()
+    public void Validate_Returns_ALVSVAL501_WhenACancelledFinalisationHasAlreadyBeenReceivedAndANewCancellationIsSent()
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newFinalisation = DataApiFinalisationFixture()
-            .With(f => f.ExternalVersion, 2)
             .With(f => f.FinalState, FinalState.CancelledAfterArrival)
             .Create();
         var existingFinalisation = DataApiFinalisationFixture()
-            .With(f => f.FinalState, FinalState.CancelledWhilePreLodged)
+            .With(f => f.FinalState, FinalState.CancelledAfterArrival)
             .Create();
         var mrn = GenerateMrn();
 
@@ -122,17 +122,17 @@ public class FinalisationValidatorTests
             }
         );
 
-        var error = FindWithErrorCode(result, "ALVSVAL404");
+        var error = FindWithErrorCode(result, "ALVSVAL501");
 
         Assert.NotNull(error);
         Assert.Contains(
-            $"An attempt to cancel EntryReference {mrn} EntryVersionNumber 2 was made but the import declaration was cancelled.",
+            $"An attempt to cancel EntryReference {mrn} EntryVersionNumber 1 was made but the import declaration was cancelled.",
             error.ErrorMessage
         );
     }
 
     [Fact]
-    public void Validate_Returns_ALVSVAL405_WhenANewFinalisationAttemptsToCancelButItIsOutOfDate()
+    public void Validate_Returns_ALVSVAL506_WhenANewFinalisationAttemptsToCancelButItIsOutOfDate()
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newFinalisation = DataApiFinalisationFixture()
@@ -152,7 +152,7 @@ public class FinalisationValidatorTests
             }
         );
 
-        var error = FindWithErrorCode(result, "ALVSVAL405");
+        var error = FindWithErrorCode(result, "ALVSVAL506");
 
         Assert.NotNull(error);
         Assert.Contains(

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ImportDocumentValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ImportDocumentValidatorTests.cs
@@ -1,0 +1,80 @@
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using FluentValidation.TestHelper;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class ImportDocumentValidatorTests
+{
+    private readonly ImportDocumentValidator _validator = new(1, "123");
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL308_WhenADocumentCodeIsInvalid()
+    {
+        var importDocument = new ImportDocument { DocumentCode = "UNKNOWN" };
+
+        var result = _validator.TestValidate(importDocument);
+        result.ShouldHaveValidationErrorFor(doc => doc.DocumentCode);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL308");
+
+        Assert.NotNull(error);
+        Assert.Contains("DocumentCode UNKNOWN on item number 1 is invalid.", error.ErrorMessage);
+    }
+
+    [Theory, ClassData(typeof(ImportDocumentValidatorTestData))]
+    public void TheoryTests(ImportDocument model, ExpectedResult expectedResult)
+    {
+        var result = _validator.TestValidate(model);
+
+        if (expectedResult.HasValidationError)
+        {
+            result.ShouldHaveValidationErrorFor(expectedResult.PropertyName);
+        }
+        else
+        {
+            result.ShouldNotHaveValidationErrorFor(expectedResult.PropertyName);
+        }
+    }
+
+    public class ImportDocumentValidatorTestData : TheoryData<ImportDocument, ExpectedResult>
+    {
+        public ImportDocumentValidatorTestData()
+        {
+            Add(
+                new ImportDocument { DocumentCode = "C633" },
+                new ExpectedResult(nameof(ImportDocument.DocumentCode), false)
+            );
+            Add(
+                new ImportDocument { DocumentCode = null },
+                new ExpectedResult(nameof(ImportDocument.DocumentCode), true)
+            );
+
+            Add(
+                new ImportDocument { DocumentStatus = "AE" },
+                new ExpectedResult(nameof(ImportDocument.DocumentStatus), false)
+            );
+            Add(
+                new ImportDocument { DocumentStatus = "AEE" },
+                new ExpectedResult(nameof(ImportDocument.DocumentStatus), true)
+            );
+            Add(
+                new ImportDocument { DocumentStatus = null },
+                new ExpectedResult(nameof(ImportDocument.DocumentStatus), true)
+            );
+
+            Add(
+                new ImportDocument { DocumentControl = "P" },
+                new ExpectedResult(nameof(ImportDocument.DocumentControl), false)
+            );
+            Add(
+                new ImportDocument { DocumentControl = "PP" },
+                new ExpectedResult(nameof(ImportDocument.DocumentControl), true)
+            );
+            Add(
+                new ImportDocument { DocumentControl = null },
+                new ExpectedResult(nameof(ImportDocument.DocumentControl), true)
+            );
+        }
+    }
+}

--- a/tests/TestFixtures/ClearanceRequestFixtures.cs
+++ b/tests/TestFixtures/ClearanceRequestFixtures.cs
@@ -2,7 +2,7 @@ using System.Security.Cryptography;
 using AutoFixture;
 using AutoFixture.Dsl;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
-using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using static Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations.CommodityValidator;
 using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
 using DataApiCustomsDeclaration = Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
@@ -10,18 +10,24 @@ namespace Defra.TradeImportsProcessor.TestFixtures;
 
 public static class ClearanceRequestFixtures
 {
-    private static readonly ClearanceRequestValidator s_validator = new();
-
     private static Fixture GetFixture()
     {
         return new Fixture();
     }
 
-    private static CommodityDocumentCheckMap GetRandomDocumentCheckMap()
+    private static AuthorityCodeMap GetRandomDocumentCheckMap()
     {
-        var withoutIuuDocuments = s_validator.CommodityDocumentCheckMap.Where(d => d.CheckCode != "H224").ToList();
+        var withoutIuuDocuments = AuthorityCodeMappings.Where(d => d.CheckCode != "H224").ToList();
 
         return withoutIuuDocuments[RandomNumberGenerator.GetInt32(0, withoutIuuDocuments.Count)];
+    }
+
+    private static string GenerateRandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        return new string(
+            Enumerable.Repeat(chars, length).Select(s => s[RandomNumberGenerator.GetInt32(0, chars.Length)]).ToArray()
+        );
     }
 
     private static T[] Repeat<T>(Func<int, T> func)
@@ -30,13 +36,20 @@ public static class ClearanceRequestFixtures
         return Enumerable.Range(1, numberRepetitions + 1).Select(func).ToArray();
     }
 
-    private static ClearanceRequestHeader GenerateHeader(int version, string? mrn = null)
+    private static ClearanceRequestHeader ClearanceRequestHeaderFixture(int version, string? mrn = null)
     {
-        return GetFixture()
+        var fixture = GetFixture();
+
+        return fixture
             .Build<ClearanceRequestHeader>()
             .With(h => h.EntryReference, mrn ?? GenerateMrn())
             .With(h => h.EntryVersionNumber, version)
             .With(h => h.PreviousVersionNumber, version - 1)
+            .With(h => h.DeclarationUcr, GenerateRandomString(35))
+            .With(h => h.DeclarantId, GenerateRandomString(18))
+            .With(h => h.DeclarantName, GenerateRandomString(35))
+            .With(h => h.DispatchCountryCode, GenerateRandomString(2))
+            .With(h => h.DeclarationType, "S")
             .Create();
     }
 
@@ -44,7 +57,7 @@ public static class ClearanceRequestFixtures
     {
         return GetFixture()
             .Build<ClearanceRequest>()
-            .With(c => c.Header, GenerateHeader(version, mrn))
+            .With(c => c.Header, ClearanceRequestHeaderFixture(version, mrn))
             .With(c => c.ServiceHeader, ServiceHeaderFixture().Create())
             .With(c => c.Items, Repeat(i => ItemFixture(i).Create()));
     }
@@ -52,24 +65,43 @@ public static class ClearanceRequestFixtures
     private static IPostprocessComposer<Item> ItemFixture(int index)
     {
         var randomDocumentCheckMap = Repeat(_ => GetRandomDocumentCheckMap());
-        var checkCodes = randomDocumentCheckMap.Select(d => d.CheckCode).ToArray();
-        var documentCodes = randomDocumentCheckMap.Select(d => d.DocumentCode).ToArray();
+        var uniqueCheckCodes = randomDocumentCheckMap.DistinctBy(d => d.Name);
+        var randomDocumentAndCheckCodes = uniqueCheckCodes
+            .OrderBy(_ => Guid.NewGuid())
+            .Take(RandomNumberGenerator.GetInt32(1, 3))
+            .ToList();
 
         return GetFixture()
             .Build<Item>()
             .With(i => i.ItemNumber, index)
-            .With(i => i.Documents, documentCodes.Select(d => DocumentFixture(d).Create()).ToArray())
-            .With(i => i.Checks, checkCodes.Select(c => CheckFixture(c).Create()).ToArray());
+            .With(i => i.CustomsProcedureCode, RandomNumberGenerator.GetInt32(1, 7).ToString)
+            .With(i => i.TaricCommodityCode, RandomNumberGenerator.GetInt32(1000000000, 1999999999).ToString)
+            .With(i => i.GoodsDescription, GenerateRandomString(280))
+            .With(i => i.ConsigneeId, GenerateRandomString(18))
+            .With(i => i.ConsigneeName, GenerateRandomString(35))
+            .With(i => i.ItemOriginCountryCode, GenerateRandomString(2))
+            .With(
+                i => i.Documents,
+                randomDocumentAndCheckCodes.Select(d => DocumentFixture(d.DocumentCode).Create()).ToArray()
+            )
+            .With(i => i.Checks, randomDocumentAndCheckCodes.Select(c => CheckFixture(c.CheckCode).Create()).ToArray());
     }
 
     private static IPostprocessComposer<Document> DocumentFixture(string documentCode)
     {
-        return GetFixture().Build<Document>().With(d => d.DocumentCode, documentCode);
+        return GetFixture()
+            .Build<Document>()
+            .With(d => d.DocumentCode, documentCode)
+            .With(d => d.DocumentStatus, GenerateRandomString(2))
+            .With(d => d.DocumentControl, GenerateRandomString(1));
     }
 
     private static IPostprocessComposer<Check> CheckFixture(string checkCode)
     {
-        return GetFixture().Build<Check>().With(c => c.CheckCode, checkCode);
+        return GetFixture()
+            .Build<Check>()
+            .With(c => c.CheckCode, checkCode)
+            .With(c => c.DepartmentCode, GenerateRandomString(8));
     }
 
     public static IPostprocessComposer<DataApiCustomsDeclaration.ClearanceRequest> DataApiClearanceRequestFixture()
@@ -80,7 +112,7 @@ public static class ClearanceRequestFixtures
             .With(c => c.Commodities, Repeat(_ => DataApiCommodityFixture().Create()));
     }
 
-    private static IPostprocessComposer<DataApiCustomsDeclaration.Commodity> DataApiCommodityFixture()
+    public static IPostprocessComposer<DataApiCustomsDeclaration.Commodity> DataApiCommodityFixture()
     {
         return GetFixture()
             .Build<DataApiCustomsDeclaration.Commodity>()


### PR DESCRIPTION
This adds some missing validation checks which are not ALVSVAL* errors.
These checks should log the message but not send it to the Data Api.

The existing tests have been reorganised around the type they are testing to avoid the nested assertions.