### PR TITLE
CDMS-476: Send message body and created time during ALVSVAL error reporting

### DIFF
--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.13.0-pr-70.352" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.15.0-pr-80.408" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />


### PR DESCRIPTION
It will be useful to record the message body and the time of creation when reporting ALVSVAL errors to more quickly follow up on them.
We only store the latest version of each record so any versions that failed validation would be discarded.