### PR TITLE
CDMS-487: Set the Created field to the ServiceCallTimestamp for Inbound Errors

### DIFF
--- a/src/Processor/Models/CustomsDeclarations/InboundError.cs
+++ b/src/Processor/Models/CustomsDeclarations/InboundError.cs
@@ -18,6 +18,7 @@ public class InboundError
     {
         return new DataApiErrors.ErrorNotification
         {
+            Created = inboundError.ServiceHeader.ServiceCallTimestamp,
             ExternalCorrelationId = inboundError.ServiceHeader.CorrelationId,
             ExternalVersion = inboundError.Header.EntryVersionNumber,
             Errors = inboundError

--- a/tests/Processor.Tests/Models/InboundErrorTests.InboundError_ConversionToDataApiInboundError_IsCorrect.verified.txt
+++ b/tests/Processor.Tests/Models/InboundErrorTests.InboundError_ConversionToDataApiInboundError_IsCorrect.verified.txt
@@ -1,6 +1,7 @@
 ﻿{
   ExternalCorrelationId: 12345,
   ExternalVersion: 1,
+  Created: 2025-04-15 12:00 Utc,
   Errors: [
     {
       Code: T04ST,


### PR DESCRIPTION
The `Created` field was unused for Inbound Errors, so we may as well set it to the time that CDS sent the message to us.