### PR TITLE
CDMS-484: Validate Inbound Error notification messages

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using Azure.Messaging.ServiceBus;
 using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Domain.Errors;
 using Defra.TradeImportsProcessor.Processor.Configuration;
 using Defra.TradeImportsProcessor.Processor.Consumers;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
@@ -148,6 +149,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IValidator<ClearanceRequestValidatorInput>, ClearanceRequestValidator>();
         services.AddScoped<IValidator<CustomsDeclarationsMessage>, CustomsDeclarationsMessageValidator>();
+        services.AddScoped<IValidator<ErrorNotification>, ErrorNotificationValidator>();
         services.AddScoped<IValidator<FinalisationValidatorInput>, FinalisationValidator>();
 
         return services;

--- a/src/Processor/Validation/CustomsDeclarations/ErrorNotificationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ErrorNotificationValidator.cs
@@ -1,0 +1,30 @@
+using System.Collections.Frozen;
+using Defra.TradeImportsDataApi.Domain.Errors;
+using FluentValidation;
+
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public class ErrorNotificationValidator : AbstractValidator<ErrorNotification>
+{
+    private static readonly FrozenSet<string> s_validInboundErrorCodes = new[]
+    {
+        "HMRCVAL101",
+        "HMRCVAL102",
+        "HMRCVAL103",
+        "HMRCVAL104",
+    }.ToFrozenSet();
+
+    public ErrorNotificationValidator()
+    {
+        RuleForEach(n => n.Errors)
+            .Must(BeAValidErrorCode)
+            .WithMessage(
+                (n, e) => $"The error code {e.Code} is not valid for correlation ID {n.ExternalCorrelationId}"
+            );
+    }
+
+    private static bool BeAValidErrorCode(ErrorNotification notification, ErrorItem item)
+    {
+        return s_validInboundErrorCodes.Contains(item.Code);
+    }
+}

--- a/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
@@ -78,7 +78,6 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
     private static bool BeAValidCancellationRequest(FinalisationValidatorInput p, FinalState finalState)
     {
         var isCancellation = finalState is FinalState.CancelledAfterArrival or FinalState.CancelledWhilePreLodged;
-
         return !isCancellation || p.ExistingClearanceRequest.ExternalVersion == p.NewFinalisation.ExternalVersion;
     }
 }

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ErrorNotificationValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ErrorNotificationValidatorTests.cs
@@ -1,0 +1,47 @@
+using AutoFixture;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using FluentValidation.TestHelper;
+using static Defra.TradeImportsProcessor.TestFixtures.InboundErrorFixtures;
+using DataApiErrors = Defra.TradeImportsDataApi.Domain.Errors;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class ErrorNotificationValidatorTests
+{
+    private readonly ErrorNotificationValidator _errorNotificationValidator = new();
+
+    [Fact]
+    public async Task Validate_ReturnsErrors_IfAnyOfTheErrorCodesAreInvalid()
+    {
+        var inboundErrorItems = new List<InboundErrorItem>
+        {
+            new InboundErrorItem { errorCode = "UNKNOWN", errorMessage = "Unknown error" },
+            new InboundErrorItem { errorCode = "HMRCVAL101", errorMessage = "A valid error code" },
+        }.ToArray();
+
+        var inboundError = (DataApiErrors.ErrorNotification)
+            InboundErrorFixture().With(i => i.Errors, inboundErrorItems).Create();
+
+        var result = await _errorNotificationValidator.TestValidateAsync(inboundError);
+
+        result.ShouldHaveValidationErrorFor(e => e.Errors);
+    }
+
+    [Fact]
+    public async Task Validate_DoesNotReturnAnError_WhenAllTheErrorCodesAreValid()
+    {
+        var inboundErrorItems = new List<InboundErrorItem>
+        {
+            new InboundErrorItem { errorCode = "HMRCVAL101", errorMessage = "A valid error code" },
+            new InboundErrorItem { errorCode = "HMRCVAL102", errorMessage = "A valid error code" },
+        }.ToArray();
+
+        var inboundError = (DataApiErrors.ErrorNotification)
+            InboundErrorFixture().With(i => i.Errors, inboundErrorItems).Create();
+
+        var result = await _errorNotificationValidator.TestValidateAsync(inboundError);
+
+        result.ShouldNotHaveValidationErrorFor(e => e.Errors);
+    }
+}

--- a/tests/TestFixtures/InboundErrorFixtures.cs
+++ b/tests/TestFixtures/InboundErrorFixtures.cs
@@ -18,7 +18,13 @@ public static class InboundErrorFixtures
         return GetFixture()
             .Build<InboundError>()
             .With(e => e.Header, HeaderFixture(mrn).Create())
-            .With(e => e.ServiceHeader, ServiceHeaderFixture().Create());
+            .With(e => e.ServiceHeader, ServiceHeaderFixture().Create())
+            .With(e => e.Errors, [InboundErrorItemFixture().Create()]);
+    }
+
+    private static IPostprocessComposer<InboundErrorItem> InboundErrorItemFixture()
+    {
+        return GetFixture().Build<InboundErrorItem>().With(e => e.errorCode, "HMRCVAL101");
     }
 
     public static IPostprocessComposer<DataApiCustomsDeclaration.InboundError> DataApiInboundErrorFixture()


### PR DESCRIPTION
This adds in a validator for Inbound Error notifications, checking the codes on the errors to be ones that we are aware of.
If a notification has any unknown codes we log and skip it.