### PR TITLE
CDMS-488: Remove JsonPropertyNames from the Gmr model

### DIFF
--- a/src/Processor/Models/Gmrs/Gmr.cs
+++ b/src/Processor/Models/Gmrs/Gmr.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Defra.TradeImportsDataApi.Domain.Gvms;
 using DataApiGvms = Defra.TradeImportsDataApi.Domain.Gvms;
 
@@ -6,53 +5,22 @@ namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
 
 public class Gmr
 {
-    [JsonPropertyName("gmrId")]
     public string? GmrId { get; init; }
-
-    [JsonPropertyName("haulierEORI")]
     public string? HaulierEori { get; init; }
-
-    [JsonPropertyName("state")]
     public string? State { get; init; }
-
-    [JsonPropertyName("inspectionRequired")]
     public bool? InspectionRequired { get; init; }
-
-    [JsonPropertyName("reportToLocations")]
     public ReportToLocations[]? ReportToLocations { get; init; }
-
-    [JsonPropertyName("updatedDateTime")]
-    public DateTime? UpdatedSource { get; init; }
-
-    [JsonPropertyName("direction")]
+    public DateTime? UpdatedDateTime { get; init; }
     public string? Direction { get; init; }
-
-    [JsonPropertyName("haulierType")]
     public string? HaulierType { get; init; }
-
-    [JsonPropertyName("isUnaccompanied")]
     public bool? IsUnaccompanied { get; init; }
-
-    [JsonPropertyName("vehicleRegNum")]
-    public string? VehicleRegistrationNumber { get; init; }
-
-    [JsonPropertyName("trailerRegistrationNums")]
+    public string? VehicleRegNum { get; init; }
     public string[]? TrailerRegistrationNums { get; init; }
-
-    [JsonPropertyName("containerReferenceNums")]
     public string[]? ContainerReferenceNums { get; init; }
-
-    [JsonPropertyName("plannedCrossing")]
-    public PlannedCrossing? PlannedCrossing { get; init; }
-
-    [JsonPropertyName("checkedInCrossing")]
-    public CheckedInCrossing? CheckedInCrossing { get; init; }
-
-    [JsonPropertyName("actualCrossing")]
-    public ActualCrossing? ActualCrossing { get; init; }
-
-    [JsonPropertyName("declarations")]
-    public Declarations? Declarations { get; init; }
+    public GmrPlannedCrossing? PlannedCrossing { get; init; }
+    public GmrCheckedInCrossing? CheckedInCrossing { get; init; }
+    public GmrActualCrossing? ActualCrossing { get; init; }
+    public GmrDeclarations? Declarations { get; init; }
 
     public static explicit operator DataApiGvms.Gmr(Gmr gmr)
     {
@@ -63,17 +31,45 @@ public class Gmr
             State = DataApiGvms.State.Open, // TO-DO: fix when enums are removed in the API
             InspectionRequired = gmr.InspectionRequired,
             ReportToLocations = gmr.ReportToLocations,
-            UpdatedSource = gmr.UpdatedSource,
+            UpdatedSource = gmr.UpdatedDateTime,
             Direction = DataApiGvms.Direction.GbToNi, // TO-DO: fix when enums are removed in the API
             HaulierType = DataApiGvms.HaulierType.Etoe, // TO-DO: fix when enums are removed in the API
             IsUnaccompanied = gmr.IsUnaccompanied,
-            VehicleRegistrationNumber = gmr.VehicleRegistrationNumber,
+            VehicleRegistrationNumber = gmr.VehicleRegNum,
             TrailerRegistrationNums = gmr.TrailerRegistrationNums,
             ContainerReferenceNums = gmr.ContainerReferenceNums,
-            PlannedCrossing = gmr.PlannedCrossing,
-            CheckedInCrossing = gmr.CheckedInCrossing,
-            ActualCrossing = gmr.ActualCrossing,
-            Declarations = gmr.Declarations,
+            PlannedCrossing =
+                gmr.PlannedCrossing != null
+                    ? new DataApiGvms.PlannedCrossing
+                    {
+                        DepartsAt = gmr.PlannedCrossing?.LocalDateTimeOfDeparture,
+                        RouteId = gmr.PlannedCrossing?.RouteId,
+                    }
+                    : null,
+            CheckedInCrossing =
+                gmr.CheckedInCrossing != null
+                    ? new DataApiGvms.CheckedInCrossing
+                    {
+                        ArrivesAt = gmr.CheckedInCrossing?.LocalDateTimeOfArrival,
+                        RouteId = gmr.CheckedInCrossing?.RouteId,
+                    }
+                    : null,
+            ActualCrossing =
+                gmr.ActualCrossing != null
+                    ? new DataApiGvms.ActualCrossing
+                    {
+                        ArrivesAt = gmr.ActualCrossing?.LocalDateTimeOfArrival,
+                        RouteId = gmr.ActualCrossing?.RouteId,
+                    }
+                    : null,
+            Declarations =
+                gmr.Declarations != null
+                    ? new DataApiGvms.Declarations
+                    {
+                        Customs = gmr.Declarations.Customs?.Select(d => new Customs { Id = d.Id }).ToArray(),
+                        Transits = gmr.Declarations.Transits?.Select(d => new Transits { Id = d.Id }).ToArray(),
+                    }
+                    : null,
         };
     }
 }

--- a/src/Processor/Models/Gmrs/GmrActualCrossing.cs
+++ b/src/Processor/Models/Gmrs/GmrActualCrossing.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+
+public class GmrActualCrossing
+{
+    public DateTime? LocalDateTimeOfArrival { get; init; }
+    public string? RouteId { get; init; }
+}

--- a/src/Processor/Models/Gmrs/GmrCheckedInCrossing.cs
+++ b/src/Processor/Models/Gmrs/GmrCheckedInCrossing.cs
@@ -1,0 +1,7 @@
+namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+
+public class GmrCheckedInCrossing
+{
+    public DateTime? LocalDateTimeOfArrival { get; init; }
+    public string? RouteId { get; init; }
+}

--- a/src/Processor/Models/Gmrs/GmrDeclaration.cs
+++ b/src/Processor/Models/Gmrs/GmrDeclaration.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+
+public class GmrDeclaration
+{
+    public string? Id { get; init; }
+}

--- a/src/Processor/Models/Gmrs/GmrDeclarations.cs
+++ b/src/Processor/Models/Gmrs/GmrDeclarations.cs
@@ -1,0 +1,7 @@
+namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+
+public class GmrDeclarations
+{
+    public GmrDeclaration[]? Customs { get; init; }
+    public GmrDeclaration[]? Transits { get; init; }
+}

--- a/src/Processor/Models/Gmrs/GmrPlannedCrossing.cs
+++ b/src/Processor/Models/Gmrs/GmrPlannedCrossing.cs
@@ -1,0 +1,7 @@
+namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+
+public class GmrPlannedCrossing
+{
+    public DateTime LocalDateTimeOfDeparture { get; init; }
+    public string? RouteId { get; init; }
+}

--- a/tests/Processor.Tests/Models/DataApi.Gmr_DeserializesCorrectly.verified.txt
+++ b/tests/Processor.Tests/Models/DataApi.Gmr_DeserializesCorrectly.verified.txt
@@ -1,0 +1,36 @@
+﻿{
+  Id: GMRAADYA9J8G,
+  HaulierEori: GB1196193155298,
+  State: Open,
+  UpdatedSource: 2025-04-18 19:00:00.353 Utc,
+  Direction: GbToNi,
+  HaulierType: Etoe,
+  IsUnaccompanied: true,
+  VehicleRegistrationNumber: RXPXOW,
+  TrailerRegistrationNums: [
+    7PIHPW,
+    E4FWLP
+  ],
+  PlannedCrossing: {
+    RouteId: 19
+  },
+  CheckedInCrossing: {
+    RouteId: 19,
+    ArrivesAt: 2025-04-28 19:00
+  },
+  ActualCrossing: {
+    RouteId: 19
+  },
+  Declarations: {
+    Transits: [
+      {
+        Id: ABCD
+      }
+    ],
+    Customs: [
+      {
+        Id: ALVSCDSSTAND9930082
+      }
+    ]
+  }
+}

--- a/tests/Processor.Tests/Models/GmrTests.Gmr_DeserializesCorrectly.verified.txt
+++ b/tests/Processor.Tests/Models/GmrTests.Gmr_DeserializesCorrectly.verified.txt
@@ -1,0 +1,38 @@
+﻿{
+  GmrId: GMRAADYA9J8G,
+  HaulierEori: GB1196193155298,
+  State: OPEN,
+  UpdatedDateTime: 2025-04-18 19:00:00.353 Utc,
+  Direction: UK_INBOUND,
+  HaulierType: NATO_MOD,
+  IsUnaccompanied: true,
+  VehicleRegNum: RXPXOW,
+  TrailerRegistrationNums: [
+    7PIHPW,
+    E4FWLP
+  ],
+  PlannedCrossing: {
+    LocalDateTimeOfDeparture: 2025-04-28 19:00,
+    RouteId: 19
+  },
+  CheckedInCrossing: {
+    LocalDateTimeOfArrival: 2025-04-28 19:00,
+    RouteId: 19
+  },
+  ActualCrossing: {
+    LocalDateTimeOfArrival: 2025-04-28 19:00,
+    RouteId: 19
+  },
+  Declarations: {
+    Customs: [
+      {
+        Id: ALVSCDSSTAND9930082
+      }
+    ],
+    Transits: [
+      {
+        Id: ABCD
+      }
+    ]
+  }
+}

--- a/tests/Processor.Tests/Models/GmrTests.cs
+++ b/tests/Processor.Tests/Models/GmrTests.cs
@@ -1,11 +1,64 @@
 using Defra.TradeImportsDataApi.Domain.Gvms;
+using Defra.TradeImportsProcessor.Processor.Models.Gmrs;
 using DataApiGvms = Defra.TradeImportsDataApi.Domain.Gvms;
 using Gmr = Defra.TradeImportsProcessor.Processor.Models.Gmrs.Gmr;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Defra.TradeImportsProcessor.Processor.Tests.Models;
 
 public class GmrTests
 {
+    [Fact]
+    public async Task Gmr_DeserializesCorrectly()
+    {
+        const string gmr = """
+            {
+              "GmrId": "GMRAADYA9J8G",
+              "HaulierEori": "GB1196193155298",
+              "State": "OPEN",
+              "InspectionRequired": null,
+              "ReportToLocations": null,
+              "UpdatedDateTime": "2025-04-18T19:00:00.353Z",
+              "Direction": "UK_INBOUND",
+              "HaulierType": "NATO_MOD",
+              "IsUnaccompanied": true,
+              "VehicleRegNum": "RXPXOW",
+              "TrailerRegistrationNums": [
+                "7PIHPW",
+                "E4FWLP"
+              ],
+              "ContainerReferenceNums": null,
+              "ActualCrossing": {
+                "LocalDateTimeOfArrival": "2025-04-28T19:00",
+                "RouteId": "19"
+              },
+              "CheckedInCrossing": {
+                "LocalDateTimeOfArrival": "2025-04-28T19:00",
+                "RouteId": "19"
+              },
+              "PlannedCrossing": {
+                "LocalDateTimeOfDeparture": "2025-04-28T19:00",
+                "RouteId": "19"
+              },
+              "Declarations": {
+                "Transits": [
+                  {
+                    "Id": "ABCD"
+                  }
+                ],
+                "Customs": [
+                  {
+                    "Id": "ALVSCDSSTAND9930082"
+                  }
+                ]
+              }
+            }
+            """;
+
+        var deserializedGmr = JsonSerializer.Deserialize<Gmr>(gmr)!;
+        await Verify(deserializedGmr).DontScrubDateTimes();
+    }
+
     [Fact]
     public async Task Gmr_ConversionToDataApiGmr_IsCorrect()
     {
@@ -18,20 +71,20 @@ public class GmrTests
             State = "OPEN",
             InspectionRequired = false,
             ReportToLocations = [new ReportToLocations { InspectionTypeId = "12345", LocationIds = ["12345"] }],
-            UpdatedSource = timestamp,
+            UpdatedDateTime = timestamp,
             Direction = "UK_INBOUND",
             HaulierType = "FPO_ASN",
             IsUnaccompanied = true,
-            VehicleRegistrationNumber = "XCR5WN",
+            VehicleRegNum = "XCR5WN",
             TrailerRegistrationNums = ["W8YK34", "P33TNV"],
             ContainerReferenceNums = ["ABCD", "EFGH"],
-            PlannedCrossing = new PlannedCrossing { DepartsAt = timestamp, RouteId = "12345" },
-            CheckedInCrossing = new CheckedInCrossing { ArrivesAt = timestamp, RouteId = "12345" },
-            ActualCrossing = new ActualCrossing { ArrivesAt = timestamp, RouteId = "12345" },
-            Declarations = new Declarations
+            PlannedCrossing = new GmrPlannedCrossing { LocalDateTimeOfDeparture = timestamp, RouteId = "12345" },
+            CheckedInCrossing = new GmrCheckedInCrossing { LocalDateTimeOfArrival = timestamp, RouteId = "12345" },
+            ActualCrossing = new GmrActualCrossing { LocalDateTimeOfArrival = timestamp, RouteId = "12345" },
+            Declarations = new GmrDeclarations
             {
-                Customs = [new Customs { Id = "12345" }],
-                Transits = [new Transits { Id = "12345" }],
+                Customs = [new GmrDeclaration { Id = "12345" }],
+                Transits = [new GmrDeclaration { Id = "12345" }],
             },
         };
 


### PR DESCRIPTION
This was taken from the legacy system but apparently did not actually work.