### PR TITLE
CDMS-462: Add the 9HCG code

### DIFF
--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -133,6 +133,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
         new("hmi", "N002", "H220"),
         new("hmi", "C085", "H218"),
         new("hmi", "C085", "H220"),
+        new("hmi", "9HCG", "H220"),
         new("phsi", "N851", "H219"),
         new("phsi", "9115", "H219"),
         new("phsi", "C085", "H219"),

--- a/src/Processor/Validation/CustomsDeclarations/DocumentByCommodity.cs
+++ b/src/Processor/Validation/CustomsDeclarations/DocumentByCommodity.cs
@@ -1,9 +1,0 @@
-using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
-
-namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
-
-public record DocumentByCommodity
-{
-    public required Commodity Commodity { get; init; }
-    public required ImportDocument Document { get; init; }
-}


### PR DESCRIPTION
This change is unrelated to CDMS-462 but it was identified during review of the ACs that 9HCG is not present in the doc to check code map.

9HCG is a legacy code that is unlikely to ever appear in the system, but it has been added just in case.

DocumentByCommodity was unused.