### PR TITLE
BAU: Add priority for each Ipaffs notification status

### DIFF
--- a/src/Processor/Consumers/ImportNotificationStatus.cs
+++ b/src/Processor/Consumers/ImportNotificationStatus.cs
@@ -2,12 +2,15 @@ namespace Defra.TradeImportsProcessor.Processor.Consumers;
 
 public static class ImportNotificationStatus
 {
-    public const string Draft = "DRAFT";
-    public const string Validated = "VALIDATED";
-    public const string Rejected = "REJECTED";
-    public const string PartiallyRejected = "PARTIALLY_REJECTED";
-    public const string InProgress = "IN_PROGRESS";
     public const string Amend = "AMEND";
     public const string Cancelled = "CANCELLED";
     public const string Deleted = "DELETED";
+    public const string Draft = "DRAFT";
+    public const string InProgress = "IN_PROGRESS";
+    public const string PartiallyRejected = "PARTIALLY_REJECTED";
+    public const string Replaced = "REPLACED";
+    public const string Rejected = "REJECTED";
+    public const string SplitConsignment = "SPLIT_CONSIGNMENT";
+    public const string Submitted = "SUBMITTED";
+    public const string Validated = "VALIDATED";
 }

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -15,15 +15,15 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
     {
         { ImportNotificationStatus.Draft, 0 },
         { ImportNotificationStatus.Deleted, 0 },
-        { ImportNotificationStatus.Amend, 1 },
-        { ImportNotificationStatus.Submitted, 2 },
-        { ImportNotificationStatus.InProgress, 3 },
-        { ImportNotificationStatus.Cancelled, 4 },
-        { ImportNotificationStatus.PartiallyRejected, 4 },
-        { ImportNotificationStatus.Rejected, 4 },
-        { ImportNotificationStatus.Validated, 4 },
-        { ImportNotificationStatus.SplitConsignment, 5 },
-        { ImportNotificationStatus.Replaced, 5 },
+        { ImportNotificationStatus.Amend, 0 },
+        { ImportNotificationStatus.Submitted, 0 },
+        { ImportNotificationStatus.InProgress, 1 },
+        { ImportNotificationStatus.Cancelled, 2 },
+        { ImportNotificationStatus.PartiallyRejected, 2 },
+        { ImportNotificationStatus.Rejected, 2 },
+        { ImportNotificationStatus.Validated, 2 },
+        { ImportNotificationStatus.SplitConsignment, 3 },
+        { ImportNotificationStatus.Replaced, 3 },
     }.ToFrozenDictionary();
 
     public async Task OnHandle(JsonElement received, CancellationToken cancellationToken)

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -206,10 +206,10 @@ public class NotificationConsumerTests
         await consumer.OnHandle(JsonSerializer.SerializeToElement(newNotification), _cancellationToken);
 
         await _mockApi
-            .DidNotReceiveWithAnyArgs()
+            .Received()
             .PutImportPreNotification(
                 Arg.Any<string>(),
-                Arg.Any<DataApiIpaffs.ImportPreNotification>(),
+                Arg.Is<DataApiIpaffs.ImportPreNotification>(n => n.Status == ImportNotificationStatus.Validated),
                 Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             );


### PR DESCRIPTION
The current logic for determining whether to update a notification is confusing and doesn't work correctly.
This adds a priority to each status which BTMS is interested in and uses that instead.