### PR TITLE
change order of interceptors being registered

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -154,8 +154,8 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddTracingForConsumers(this IServiceCollection services)
     {
-        services.AddSingleton(typeof(IConsumerInterceptor<>), typeof(LoggingInterceptor<>));
         services.AddScoped(typeof(IConsumerInterceptor<>), typeof(TraceContextInterceptor<>));
+        services.AddSingleton(typeof(IConsumerInterceptor<>), typeof(LoggingInterceptor<>));
         services.AddSingleton(typeof(IServiceBusConsumerErrorHandler<>), typeof(SerilogTraceErrorHandler<>));
 
         return services;


### PR DESCRIPTION
logging interceptor needs to happen after the trace interceptor because that is what sets up the trace id