### PR TITLE
CDMS-655: Send FinalState as a string to match the Data Api spec

### DIFF
--- a/src/Processor/Extensions/DataApiCustomsDeclarationFinalisationExtensions.cs
+++ b/src/Processor/Extensions/DataApiCustomsDeclarationFinalisationExtensions.cs
@@ -1,0 +1,10 @@
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using DataApiCustomsDeclaration = Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+
+namespace Defra.TradeImportsProcessor.Processor.Extensions;
+
+public static class DataApiCustomsDeclarationFinalisationExtensions
+{
+    public static FinalStateValues FinalStateValue(this DataApiCustomsDeclaration.Finalisation finalisation) =>
+        Enum.Parse<FinalStateValues>(finalisation.FinalState);
+}

--- a/src/Processor/Models/CustomsDeclarations/FinalStateValues.cs
+++ b/src/Processor/Models/CustomsDeclarations/FinalStateValues.cs
@@ -1,0 +1,26 @@
+namespace Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+
+public enum FinalStateValues
+{
+    // From https://eaflood.atlassian.net/wiki/spaces/ALVS/pages/5176590480/FinalState+Field
+    Cleared = 0,
+    CancelledAfterArrival = 1,
+    CancelledWhilePreLodged = 2,
+    Destroyed = 3,
+    Seized = 4,
+    ReleasedToKingsWarehouse = 5,
+    TransferredToMss = 6,
+}
+
+public static class FinalStateExtensions
+{
+    public static bool IsCancelled(this FinalStateValues finalStateValues)
+    {
+        return finalStateValues is FinalStateValues.CancelledAfterArrival or FinalStateValues.CancelledWhilePreLodged;
+    }
+
+    public static bool IsNotCancelled(this FinalStateValues finalStateValues)
+    {
+        return !finalStateValues.IsCancelled();
+    }
+}

--- a/src/Processor/Models/CustomsDeclarations/Finalisation.cs
+++ b/src/Processor/Models/CustomsDeclarations/Finalisation.cs
@@ -19,7 +19,7 @@ public class Finalisation
             MessageSentAt = finalisation.ServiceHeader.ServiceCallTimestamp!,
             ExternalVersion = finalisation.Header.EntryVersionNumber,
             DecisionNumber = finalisation.Header.DecisionNumber,
-            FinalState = (DataApiCustomsDeclaration.FinalState)int.Parse(finalisation.Header.FinalState),
+            FinalState = finalisation.Header.FinalState,
             IsManualRelease = finalisation.Header.ManualAction == "Y",
         };
     }

--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.19.0-pr-88.507" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.20.0-pr-98.564" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Extensions;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using FluentValidation;
 using DataApiCustomsDeclaration = Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
@@ -109,6 +110,6 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
 
     private static bool NotBeCancelled(Finalisation? existingFinalisation)
     {
-        return !existingFinalisation?.FinalState.IsCancelled() ?? true;
+        return !existingFinalisation?.FinalStateValue().IsCancelled() ?? true;
     }
 }

--- a/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -135,7 +135,7 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
         var mrn = GenerateMrn();
         var clearanceRequest = DataApiClearanceRequestFixture().Create();
         var finalisationHeader = FinalisationHeaderFixture((int)clearanceRequest.ExternalVersion!, mrn)
-            .With(h => h.FinalState, ((int)FinalState.Cleared).ToString())
+            .With(h => h.FinalState, ((int)FinalStateValues.Cleared).ToString())
             .Create();
         var finalisation = FinalisationFixture(mrn).With(f => f.Header, finalisationHeader).Create();
 

--- a/tests/Processor.Tests/Models/FinalisationTests.Finalisation_ConversionToDataApiFinalisation_IsCorrect.verified.txt
+++ b/tests/Processor.Tests/Models/FinalisationTests.Finalisation_ConversionToDataApiFinalisation_IsCorrect.verified.txt
@@ -3,6 +3,6 @@
   MessageSentAt: 2025-04-15 12:00 Utc,
   ExternalVersion: 1,
   DecisionNumber: 1,
-  FinalState: CancelledAfterArrival,
+  FinalState: 1,
   IsManualRelease: true
 }

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
@@ -1,11 +1,13 @@
 using AutoFixture;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
 using FluentValidation.Results;
 using FluentValidation.TestHelper;
 using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.FinalisationFixtures;
+using ClearanceRequest = Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ClearanceRequest;
 using CommodityCheck = Defra.TradeImportsDataApi.Domain.CustomsDeclaration.CommodityCheck;
 
 namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
@@ -116,14 +118,14 @@ public class ClearanceRequestValidatorTests
     }
 
     [Theory]
-    [InlineData(FinalState.CancelledAfterArrival)]
-    [InlineData(FinalState.CancelledWhilePreLodged)]
-    public void Validate_Returns_ALVSVAL324_WhenClearanceRequestIsCancelled(FinalState finalState)
+    [InlineData(FinalStateValues.CancelledAfterArrival)]
+    [InlineData(FinalStateValues.CancelledWhilePreLodged)]
+    public void Validate_Returns_ALVSVAL324_WhenClearanceRequestIsCancelled(FinalStateValues finalState)
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newClearanceRequest = DataApiClearanceRequestFixture().Create();
         var mrn = GenerateMrn();
-        var existingFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, finalState).Create();
+        var existingFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, finalState.ToString).Create();
 
         var result = _validator.Validate(
             new ClearanceRequestValidatorInput
@@ -144,7 +146,9 @@ public class ClearanceRequestValidatorTests
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newClearanceRequest = DataApiClearanceRequestFixture().Create();
         var mrn = GenerateMrn();
-        var existingFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, FinalState.Cleared).Create();
+        var existingFinalisation = DataApiFinalisationFixture()
+            .With(f => f.FinalState, FinalStateValues.Cleared.ToString)
+            .Create();
 
         var result = _validator.Validate(
             new ClearanceRequestValidatorInput

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
@@ -24,7 +24,7 @@ public class FinalisationValidatorTests
         var existingClearanceRequest = DataApiClearanceRequestFixture().With(c => c.ExternalVersion, 2).Create();
         var newFinalisation = DataApiFinalisationFixture()
             .With(f => f.ExternalVersion, 1)
-            .With(f => f.FinalState, FinalState.ReleasedToKingsWarehouse)
+            .With(f => f.FinalState, FinalStateValues.ReleasedToKingsWarehouse.ToString)
             .Create();
         var mrn = GenerateMrn();
 
@@ -50,7 +50,7 @@ public class FinalisationValidatorTests
     public void Validate_Returns_ALVSVAL402_WhenTheFinalStateIsUnknown()
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
-        var newFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, (FinalState)999).Create();
+        var newFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, "999").Create();
 
         var result = _validator.Validate(
             new FinalisationValidatorInput
@@ -74,10 +74,10 @@ public class FinalisationValidatorTests
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newFinalisation = DataApiFinalisationFixture()
             .With(f => f.ExternalVersion, 2)
-            .With(f => f.FinalState, FinalState.Cleared)
+            .With(f => f.FinalState, FinalStateValues.Cleared.ToString)
             .Create();
         var existingFinalisation = DataApiFinalisationFixture()
-            .With(f => f.FinalState, FinalState.CancelledWhilePreLodged)
+            .With(f => f.FinalState, FinalStateValues.CancelledWhilePreLodged.ToString)
             .Create();
         var mrn = GenerateMrn();
 
@@ -105,10 +105,10 @@ public class FinalisationValidatorTests
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newFinalisation = DataApiFinalisationFixture()
-            .With(f => f.FinalState, FinalState.CancelledAfterArrival)
+            .With(f => f.FinalState, FinalStateValues.CancelledAfterArrival.ToString)
             .Create();
         var existingFinalisation = DataApiFinalisationFixture()
-            .With(f => f.FinalState, FinalState.CancelledAfterArrival)
+            .With(f => f.FinalState, FinalStateValues.CancelledAfterArrival.ToString)
             .Create();
         var mrn = GenerateMrn();
 
@@ -137,9 +137,11 @@ public class FinalisationValidatorTests
         var existingClearanceRequest = DataApiClearanceRequestFixture().Create();
         var newFinalisation = DataApiFinalisationFixture()
             .With(f => f.ExternalVersion, 2)
-            .With(f => f.FinalState, FinalState.CancelledAfterArrival)
+            .With(f => f.FinalState, FinalStateValues.CancelledAfterArrival.ToString)
             .Create();
-        var existingFinalisation = DataApiFinalisationFixture().With(f => f.FinalState, FinalState.Seized).Create();
+        var existingFinalisation = DataApiFinalisationFixture()
+            .With(f => f.FinalState, FinalStateValues.Seized.ToString)
+            .Create();
         var mrn = GenerateMrn();
 
         var result = _validator.Validate(


### PR DESCRIPTION
The Data Api is now expecting a string for the FinalState.