### PR TITLE
Remove need to run the service in DEVELOPMENT mode to drive use of the CDP proxy

### DIFF
--- a/src/Processor/Configuration/CdpOptions.cs
+++ b/src/Processor/Configuration/CdpOptions.cs
@@ -6,4 +6,6 @@ public class CdpOptions
 {
     [ConfigurationKeyName("CDP_HTTPS_PROXY")]
     public string? CdpHttpsProxy { get; init; }
+
+    public bool IsProxyEnabled => !string.IsNullOrWhiteSpace(CdpHttpsProxy);
 }

--- a/src/Processor/Extensions/CdpServiceBusClientFactory.cs
+++ b/src/Processor/Extensions/CdpServiceBusClientFactory.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using Azure.Messaging.ServiceBus;
+using Defra.TradeImportsProcessor.Processor.Configuration;
+using Microsoft.Extensions.Options;
 using SlimMessageBus.Host.AzureServiceBus;
 
 namespace Defra.TradeImportsProcessor.Processor.Extensions;
@@ -11,7 +13,7 @@ public static class CdpServiceBusClientFactory
         ServiceBusMessageBusSettings busSettings
     )
     {
-        var clientOptions = serviceProvider.GetRequiredService<IHostEnvironment>().IsDevelopment()
+        var clientOptions = !serviceProvider.GetRequiredService<IOptions<CdpOptions>>().Value.IsProxyEnabled
             ? new ServiceBusClientOptions()
             : new ServiceBusClientOptions
             {

--- a/src/Processor/Health/AsbHealthCheckBuilderExtensions.cs
+++ b/src/Processor/Health/AsbHealthCheckBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Defra.TradeImportsProcessor.Processor.Configuration;
 using HealthChecks.AzureServiceBus;
 using HealthChecks.AzureServiceBus.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Defra.TradeImportsProcessor.Processor.Health;
 
@@ -54,7 +55,7 @@ public static class AsbHealthCheckBuilderExtensions
     {
         public override ServiceBusClient CreateClient(string? connectionString)
         {
-            var clientOptions = serviceProvider.GetRequiredService<IHostEnvironment>().IsDevelopment()
+            var clientOptions = !serviceProvider.GetRequiredService<IOptions<CdpOptions>>().Value.IsProxyEnabled
                 ? new ServiceBusClientOptions()
                 : new ServiceBusClientOptions
                 {


### PR DESCRIPTION
Without this change, the processor service cannot be run locally via Docker in PRODUCTION mode ie. when ASPNETCORE_ENVIRONMENT is set to anything other than DEVELOPMENT.

This PR alters the logic to drive proxy use based on the `CdpOptions` already in existence.