### PR TITLE
CDMS-689: Add ticket numbers to validation rules, tweak rules

### DIFF
--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.AzureServiceBus" Version="9.0.0" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.23.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.24.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
@@ -7,6 +7,7 @@ public class CheckValidator : AbstractValidator<CommodityCheck>
 {
     public CheckValidator(int itemNumber, string correlationId)
     {
+        // CDMS-258
         RuleFor(p => p.CheckCode)
             .NotEmpty()
             .WithMessage(_ =>

--- a/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CheckValidator.cs
@@ -7,6 +7,9 @@ public class CheckValidator : AbstractValidator<CommodityCheck>
 {
     public CheckValidator(int itemNumber, string correlationId)
     {
+        RuleFor(p => p.CheckCode).MaximumLength(4);
+        RuleFor(p => p.DepartmentCode).NotEmpty().MaximumLength(8);
+
         // CDMS-258
         RuleFor(p => p.CheckCode)
             .NotEmpty()
@@ -14,8 +17,5 @@ public class CheckValidator : AbstractValidator<CommodityCheck>
                 $"The CheckCode field on item number {itemNumber} must have a value. Your service request with Correlation ID {correlationId} has been terminated."
             )
             .WithState(_ => "ALVSVAL311");
-
-        RuleFor(p => p.CheckCode).MaximumLength(4);
-        RuleFor(p => p.DepartmentCode).NotEmpty().MaximumLength(8);
     }
 }

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
@@ -29,14 +29,6 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
             )
             .When(p => p.NewClearanceRequest.ExternalVersion > 1);
 
-        // CDMS-256
-        RuleFor(p => p.NewClearanceRequest.ExternalVersion)
-            .NotNull()
-            .WithState(_ => "ALVSVAL153")
-            .WithMessage(p =>
-                $"EntryVersionNumber has not been provided for the import document. Provide an EntryVersionNumber. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-            );
-
         // CDMS-257 - NEW
         RuleForEach(p =>
                 (p.NewClearanceRequest.Commodities ?? Array.Empty<Commodity>()).GroupBy(c => c.ItemNumber).ToList()

--- a/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ClearanceRequestValidator.cs
@@ -19,6 +19,7 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
         RuleForEach(p => p.NewClearanceRequest.Commodities)
             .SetValidator(p => new CommodityValidator(p.NewClearanceRequest.ExternalCorrelationId!));
 
+        // CDMS-255
         RuleFor(p => p.NewClearanceRequest.PreviousExternalVersion)
             .NotNull()
             .WithState(_ => "ALVSVAL152")
@@ -26,19 +27,6 @@ public class ClearanceRequestValidator : AbstractValidator<ClearanceRequestValid
                 $"PreviousVersionNumber has not been provided for the import document. Provide a PreviousVersionNumber. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
             )
             .When(p => p.NewClearanceRequest.ExternalVersion > 1);
-
-        When(
-            p => p.NewClearanceRequest.ExternalVersion != 1,
-            () =>
-            {
-                RuleFor(p => p.NewClearanceRequest.PreviousExternalVersion)
-                    .NotNull()
-                    .WithState(_ => "ALVSVAL152")
-                    .WithMessage(p =>
-                        $"PreviousVersionNumber has not been provided for the import document. Provide a PreviousVersionNumber. Your request with correlation ID {p.NewClearanceRequest.ExternalCorrelationId} has been terminated."
-                    );
-            }
-        );
 
         RuleFor(p => p.NewClearanceRequest.ExternalVersion)
             .NotNull()

--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -22,6 +22,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
             .SetValidator(item => new ImportDocumentValidator((int)item.ItemNumber!, correlationId));
         RuleForEach(p => p.Checks).SetValidator(item => new CheckValidator((int)item.ItemNumber!, correlationId));
 
+        // CDMS-275 - NEW
         RuleFor(p => p.SupplementaryUnits)
             .Must(HaveAValidCommodityDecimalFormat)
             .WithState(_ => "ALVSVAL108")
@@ -29,6 +30,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
                 $"Supplementary units format on item number {p.ItemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated. Enter it in the format 99999999999.999."
             );
 
+        // CDMS-254 - NEW
         RuleFor(p => p.NetMass)
             .Must(HaveAValidCommodityDecimalFormat)
             .WithState(_ => "ALVSVAL109")
@@ -36,6 +38,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
                 $"Net mass format on item number {p.ItemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated. Enter it in the format 99999999999.999."
             );
 
+        // CDMS-249 - NEW - REVIEW ACs
         RuleFor(p => p.Documents)
             .NotEmpty()
             .WithState(_ => "ALVSVAL318")
@@ -43,6 +46,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
                 $"Item {p.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated."
             );
 
+        // CDMS-265
         RuleForEach(p => p.Documents)
             .Must(MustHaveCorrectDocumentCodesForChecks)
             .WithMessage(
@@ -52,6 +56,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
             .WithState(_ => "ALVSVAL320")
             .When(p => p.Checks is not null);
 
+        // CDMS-328
         RuleForEach(p => p.Checks)
             .Must(MustHaveDocumentForCheck)
             .WithMessage(
@@ -60,6 +65,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
             )
             .WithState(_ => "ALVSVAL321");
 
+        // CDMS-327 - DISABLED
         RuleFor(p => p.Checks)
             .Must(MustOnlyHaveOneCheckPerAuthority!)
             .WithMessage(p =>
@@ -68,6 +74,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
             .WithState(_ => "ALVSVAL317")
             .When(p => p.Checks is not null);
 
+        // CDMS-267
         RuleFor(p => p.Checks)
             .Must(MustHavePoAoCheck!)
             .WithMessage(p =>
@@ -76,6 +83,7 @@ public class CommodityValidator : AbstractValidator<Commodity>
             .WithState(_ => "ALVSVAL328")
             .When(x => x.Checks is not null && x.Checks.Any(y => y.CheckCode == "H224"));
 
+        // CDMS-276
         RuleFor(p => p.Documents)
             .NotEmpty()
             .WithMessage(c =>

--- a/src/Processor/Validation/CustomsDeclarations/ErrorNotificationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ErrorNotificationValidator.cs
@@ -16,6 +16,7 @@ public class ErrorNotificationValidator : AbstractValidator<ErrorNotification>
 
     public ErrorNotificationValidator()
     {
+        // ???
         RuleForEach(n => n.Errors)
             .Must(BeAValidErrorCode)
             .WithMessage(

--- a/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
@@ -11,21 +11,12 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
     {
         RuleFor(p => p.NewFinalisation.ExternalVersion).NotNull().InclusiveBetween(1, 99);
 
-        // INCORRECT CODE
+        // INCORRECT ERROR CODE
         RuleFor(p => p.Mrn)
             .NotEmpty()
             .MaximumLength(22)
             .Matches("[1-9]{2}[A-Za-z]{2}[A-Za-z0-9]{14}")
             .WithState(_ => "ALVSVAL401");
-
-        // CDMS-268
-        //Disabled as part of https://eaflood.atlassian.net/browse/CDMS-685 until we better understand this rule
-        ////RuleFor(p => p.NewFinalisation.FinalStateValue())
-        ////    .Must(BeANewFinalisation)
-        ////    .WithState(_ => "ALVSVAL401")
-        ////    .WithMessage(p =>
-        ////        $"The finalised state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion}. This has already been replaced by a later version of the import declaration. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
-        ////    );
 
         // CDMS-269 - NEW
         RuleFor(p => p.NewFinalisation)
@@ -36,29 +27,44 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
                     $"The FinalState {f.FinalState} is invalid. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
             );
 
-        // CDMS-270
-        RuleFor(p => p.ExistingFinalisation)
-            .Must(NotBeAlreadyCancelled)
-            .WithState(_ => "ALVSVAL403")
-            .WithMessage(p =>
-                $"The final state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
-            );
+        When(
+            p => p.ExistingFinalisation is not null,
+            () =>
+            {
+                // CDMS-268
+                //Disabled as part of https://eaflood.atlassian.net/browse/CDMS-685 until we better understand this rule
+                ////RuleFor(p => p.NewFinalisation.FinalStateValue())
+                ////    .Must(BeANewFinalisation)
+                ////    .WithState(_ => "ALVSVAL401")
+                ////    .WithMessage(p =>
+                ////        $"The finalised state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion}. This has already been replaced by a later version of the import declaration. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+                ////    );
 
-        // CDMS-271
-        RuleFor(p => p.NewFinalisation.FinalStateValue())
-            .Must(NotBeACancellationWhenAlreadyCancelled)
-            .WithState(_ => "ALVSVAL501")
-            .WithMessage(p =>
-                $"An attempt to cancel EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} was made but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
-            );
+                // CDMS-270
+                RuleFor(p => p.ExistingFinalisation!)
+                    .Must(NotBeAlreadyCancelled)
+                    .WithState(_ => "ALVSVAL403")
+                    .WithMessage(p =>
+                        $"The final state was received for EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+                    );
 
-        // CDMS-272
-        RuleFor(p => p.NewFinalisation.FinalStateValue())
-            .Must(BeAValidCancellationRequest)
-            .WithState(_ => "ALVSVAL506")
-            .WithMessage(p =>
-                $"The import declaration was received as a cancellation. The EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} have already been replaced by a later version. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
-            );
+                // CDMS-271
+                RuleFor(p => p.NewFinalisation.FinalStateValue())
+                    .Must(NotBeACancellationWhenAlreadyCancelled)
+                    .WithState(_ => "ALVSVAL501")
+                    .WithMessage(p =>
+                        $"An attempt to cancel EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} was made but the import declaration was cancelled. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+                    );
+
+                // CDMS-272
+                RuleFor(p => p.NewFinalisation.FinalStateValue())
+                    .Must(BeAValidCancellationRequest)
+                    .WithState(_ => "ALVSVAL506")
+                    .WithMessage(p =>
+                        $"The import declaration was received as a cancellation. The EntryReference {p.Mrn} EntryVersionNumber {p.NewFinalisation.ExternalVersion} have already been replaced by a later version. Your request with correlation ID {p.NewFinalisation.ExternalCorrelationId} has been terminated."
+                    );
+            }
+        );
     }
 
     //Disabled as part of https://eaflood.atlassian.net/browse/CDMS-685 until we better understand this rule
@@ -68,9 +74,9 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
     ////        && p.NewFinalisation.ExternalVersion == p.ExistingClearanceRequest.ExternalVersion;
     ////}
 
-    private static bool NotBeAlreadyCancelled(FinalisationValidatorInput p, Finalisation? existingFinalisation)
+    private static bool NotBeAlreadyCancelled(FinalisationValidatorInput p, Finalisation existingFinalisation)
     {
-        return existingFinalisation == null || existingFinalisation.FinalStateValue().IsNotCancelled();
+        return existingFinalisation.FinalStateValue().IsNotCancelled();
     }
 
     private static bool NotBeACancellationWhenAlreadyCancelled(

--- a/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/FinalisationValidator.cs
@@ -11,6 +11,7 @@ public class FinalisationValidator : AbstractValidator<FinalisationValidatorInpu
     {
         RuleFor(p => p.NewFinalisation.ExternalVersion).NotNull().InclusiveBetween(1, 99);
 
+        // INCORRECT CODE
         RuleFor(p => p.Mrn)
             .NotEmpty()
             .MaximumLength(22)

--- a/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
@@ -7,19 +7,21 @@ public class HeaderValidator : AbstractValidator<Header>
 {
     public HeaderValidator(string correlationId)
     {
+        RuleFor(p => p.EntryVersionNumber).InclusiveBetween(1, 99);
+
+        // COPIED FROM BTMS-BACKEND - UNSURE OF CORRECT ALVSVAL
         RuleFor(p => p.EntryReference)
             .NotEmpty()
             .MaximumLength(22)
             .Matches("[1-9]{2}[A-Za-z]{2}[A-Za-z0-9]{14}")
             .WithState(p => "ALVSVAL303");
 
+        // CDMS-256
         RuleFor(p => p.EntryVersionNumber)
             .NotNull()
             .WithState(p => "ALVSVAL153")
             .WithMessage(p =>
                 $"EntryVersionNumber has not been provided for the import document. Provide an EntryVersionNumber. Your request with correlation ID {correlationId} has been terminated."
             );
-
-        RuleFor(p => p.EntryVersionNumber).InclusiveBetween(1, 99);
     }
 }

--- a/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/HeaderValidator.cs
@@ -18,7 +18,7 @@ public class HeaderValidator : AbstractValidator<Header>
 
         // CDMS-256
         RuleFor(p => p.EntryVersionNumber)
-            .NotNull()
+            .NotEmpty()
             .WithState(p => "ALVSVAL153")
             .WithMessage(p =>
                 $"EntryVersionNumber has not been provided for the import document. Provide an EntryVersionNumber. Your request with correlation ID {correlationId} has been terminated."

--- a/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
@@ -7,6 +7,7 @@ public class ImportDocumentValidator : AbstractValidator<ImportDocument>
 {
     public ImportDocumentValidator(int itemNumber, string correlationId)
     {
+        // CDMS-276
         RuleFor(p => p.DocumentCode)
             .Must(BeAValidDocumentCode!)
             .WithMessage(c =>

--- a/src/Processor/Validation/CustomsDeclarations/ServiceHeaderValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ServiceHeaderValidator.cs
@@ -7,6 +7,9 @@ public class ServiceHeaderValidator : AbstractValidator<ServiceHeader>
 {
     public ServiceHeaderValidator()
     {
+        RuleFor(p => p.CorrelationId).NotEmpty().MaximumLength(20);
+
+        // CDMS-252
         RuleFor(p => p.SourceSystem)
             .Must(p => p == "CDS")
             .WithMessage(c =>
@@ -14,13 +17,12 @@ public class ServiceHeaderValidator : AbstractValidator<ServiceHeader>
             )
             .WithState(p => "ALVSVAL101");
 
+        // CDMS-253
         RuleFor(p => p.DestinationSystem)
             .Must(p => p == "ALVS")
             .WithMessage(c =>
                 $"Destination system {c.DestinationSystem} is invalid. Your request with correlation ID {c.CorrelationId} has been terminated."
             )
             .WithState(p => "ALVSVAL102");
-
-        RuleFor(p => p.CorrelationId).NotEmpty().MaximumLength(20);
     }
 }

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ClearanceRequestValidatorTests.cs
@@ -37,18 +37,6 @@ public class ClearanceRequestValidatorTests
     }
 
     [Fact]
-    public void Validate_Returns_ALVSVAL153_WhenEntryVersionNumberNotSet()
-    {
-        var newClearanceRequest = DataApiClearanceRequestFixture().With(c => c.ExternalVersion, (int?)null).Create();
-
-        var result = _validator.Validate(
-            new ClearanceRequestValidatorInput { Mrn = GenerateMrn(), NewClearanceRequest = newClearanceRequest }
-        );
-
-        Assert.NotNull(FindWithErrorCode(result, "ALVSVAL153"));
-    }
-
-    [Fact]
     public void Validate_Returns_ALVSVAL164_WhenAnItemNumberAppearsMoreThanOnce()
     {
         Commodity[] commodities = [new() { ItemNumber = 1 }, new() { ItemNumber = 2 }, new() { ItemNumber = 2 }];

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/HeaderValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/HeaderValidatorTests.cs
@@ -1,0 +1,25 @@
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+using FluentValidation.Results;
+
+namespace Defra.TradeImportsProcessor.Processor.Tests.Validation.CustomsDeclarations;
+
+public class HeaderValidatorTests
+{
+    private readonly HeaderValidator _validator = new("123");
+
+    private static ValidationFailure? FindWithErrorCode(ValidationResult result, string errorCode)
+    {
+        return result.Errors.Find(s => (string)s.CustomState == errorCode);
+    }
+
+    [Fact]
+    public void Validate_Returns_ALVSVAL153_WhenEntryVersionNumberNotSet()
+    {
+        var header = new Header { EntryReference = "ref" };
+
+        var result = _validator.Validate(header);
+
+        Assert.NotNull(FindWithErrorCode(result, "ALVSVAL153"));
+    }
+}


### PR DESCRIPTION
This adds the ticket numbers to the validation rules to more easily find them in Jira.

One of the rules was a duplicate which would not have been triggered, so has been removed.

The validation rules have been changed to be closer to what btms-backend had, but the tests have not been changed.