### PR TITLE
CDMS-689: Log the ALVS error code if present

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -41,7 +41,7 @@ public class CustomsDeclarationsConsumer(
                 mrn,
                 customsDeclarationsMessage.Header.EntryVersionNumber,
                 messageType,
-                error.ErrorCode,
+                error.CustomState ?? error.ErrorCode,
                 error.ErrorMessage
             )
         );

--- a/src/Processor/Consumers/GmrsConsumer.cs
+++ b/src/Processor/Consumers/GmrsConsumer.cs
@@ -25,7 +25,7 @@ public class GmrsConsumer(
             logger.LogInformation(
                 "Gmr {GmrId} failed validation with {ErrorCode}: {ErrorMessage}",
                 gmr.GmrId,
-                error.ErrorCode,
+                error.CustomState ?? error.ErrorCode,
                 error.ErrorMessage
             )
         );


### PR DESCRIPTION
It is useful to see in the logs which ALVS error code has been triggered, if present.