### PR TITLE
CDMS-698: Exclude IUU Check Codes from ALVSVAL317

### DIFF
--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -116,9 +116,14 @@ public class CommodityValidator : AbstractValidator<Commodity>
         return length <= 14 && numDecimals <= 3;
     }
 
+    private static bool IsNotAnIuuCheckCode(string? checkCode)
+    {
+        return checkCode != "H224";
+    }
+
     private static bool MustOnlyHaveOneCheckPerAuthority(Commodity commodity, CommodityCheck[] checks)
     {
-        var checkCodes = checks.Select(x => x.CheckCode);
+        var checkCodes = checks.Select(x => x.CheckCode).Where(IsNotAnIuuCheckCode);
 
         var authorityCheckCodeMatches = AuthorityCodeMappings
             .DistinctBy(a => a.CheckCode)

--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -118,9 +118,14 @@ public class CommodityValidator : AbstractValidator<Commodity>
 
     private static bool MustOnlyHaveOneCheckPerAuthority(Commodity commodity, CommodityCheck[] checks)
     {
-        // Revert commit for true implementation when needed
-        // See ticket CDMS-674 for why validation has been disabled
-        return true;
+        var checkCodes = checks.Select(x => x.CheckCode);
+
+        var authorityCheckCodeMatches = AuthorityCodeMappings
+            .DistinctBy(a => a.CheckCode)
+            .Where(a => checkCodes.Contains(a.CheckCode))
+            .GroupBy(a => a.Name);
+
+        return authorityCheckCodeMatches.All(a => a.Count() <= 1);
     }
 
     private static bool MustHavePoAoCheck(Commodity commodity, CommodityCheck[] checks)

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -71,9 +71,8 @@ public class CommodityValidatorTests
 
         var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL317");
 
-        // Revert commit for true assertion when needed
-        // See ticket CDMS-674 for why validation has been disabled
-        Assert.Null(error);
+        Assert.NotNull(error);
+        Assert.Contains("Item 1 has more than one Item Check defined for the same authority.", error.ErrorMessage);
     }
 
     [Fact]

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -76,6 +76,26 @@ public class CommodityValidatorTests
     }
 
     [Fact]
+    public void Validate_DoesNotReturn_ALVSVAL317_WhenThereAreTwoChecks_ButAnIUUCheckCodeIsSpecified()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 1,
+            Checks =
+            [
+                new CommodityCheck { CheckCode = "H224", DepartmentCode = "HMI" },
+                new CommodityCheck { CheckCode = "H222", DepartmentCode = "HMI" },
+            ],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL317");
+
+        Assert.Null(error);
+    }
+
+    [Fact]
     public void Validate_Returns_ALVSVAL318_WhenADocumentIsNotProvidedForCommodity()
     {
         var commodity = new Commodity { ItemNumber = 1 };


### PR DESCRIPTION
The IUU Check Code H224 is usually specified alongside H222, which causes ALVSVAL317 to trigger because we only allow one check per authority.
IUU Check Codes should be excluded from this rule and the validation should only run on the remaining check codes.