### PR TITLE
CDMS-699: Exclude GMS Notifications from ALVSVAL318

### DIFF
--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -38,13 +38,14 @@ public class CommodityValidator : AbstractValidator<Commodity>
                 $"Net mass format on item number {p.ItemNumber} is invalid. Your request with correlation ID {correlationId} has been terminated. Enter it in the format 99999999999.999."
             );
 
-        // CDMS-249 - NEW - REVIEW ACs
+        // CDMS-249 - NEW
         RuleFor(p => p.Documents)
             .NotEmpty()
             .WithState(_ => "ALVSVAL318")
             .WithMessage(p =>
                 $"Item {p.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated."
-            );
+            )
+            .When(IsNotAGmsNotification);
 
         // CDMS-265
         RuleForEach(p => p.Documents)
@@ -90,6 +91,11 @@ public class CommodityValidator : AbstractValidator<Commodity>
                 $"Item {c.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated.."
             )
             .WithState(_ => "ALVSVAL308");
+    }
+
+    private static bool IsNotAGmsNotification(Commodity commodity)
+    {
+        return commodity.Checks == null || commodity.Checks.All(c => c.CheckCode != "H220");
     }
 
     private static bool MustHaveCorrectDocumentCodesForChecks(Commodity commodity, ImportDocument importDocument)

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -110,6 +110,19 @@ public class CommodityValidatorTests
     }
 
     [Fact]
+    public void Validate_DoesNotReturn_ALVSVAL318_WhenADocumentIsNotProvidedForCommodity_ButItIsAGmrNotification()
+    {
+        var commodity = new Commodity { ItemNumber = 1, Checks = [new CommodityCheck { CheckCode = "H220" }] };
+
+        var result = _validator.TestValidate(commodity);
+        result.ShouldHaveValidationErrorFor(c => c.Documents);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL318");
+
+        Assert.Null(error);
+    }
+
+    [Fact]
     public void Validate_Returns_ALVSVAL320_WhenTheCheckCodesSpecified_ButAreNotRelevantToTheDocumentCodes()
     {
         var commodity = new Commodity


### PR DESCRIPTION
GMS Notifications with a CheckCode of H220 do not need a document to be specified and should not trigger ALVSVAL318.