### PR TITLE
CDMS-700: Exclude GMS check codes from ALVSVAL321

### DIFF
--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -161,6 +161,22 @@ public class CommodityValidatorTests
     }
 
     [Fact]
+    public void Validate_DoesNotReturn_ALVSVAL321_WhenCheckCodesAreSpecified_NoDocumentsAreSpecified_ButTheCodeCodeIsForGms()
+    {
+        var commodity = new Commodity
+        {
+            ItemNumber = 2,
+            Checks = [new CommodityCheck { CheckCode = "H220", DepartmentCode = "PHA" }],
+        };
+
+        var result = _validator.TestValidate(commodity);
+
+        var errors = result.Errors.Where(e => (string)e.CustomState == "ALVSVAL321").ToList();
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void Validate_Returns_ALVSVAL328_WhenAnIuuCheckIsSpecifiedButHasNoPoaoCheck()
     {
         var commodity = new Commodity


### PR DESCRIPTION
When a GMS check code is specified, it does not require an associated document to be specified along side it.
This removes any GMS check codes from being validated for ALVSVAL321.