### PR TITLE
CDMS-701: Re-enable ALSVAL401 with updated logic

### DIFF
--- a/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/FinalisationValidatorTests.cs
@@ -18,10 +18,8 @@ public class FinalisationValidatorTests
         return result.Errors.Find(s => (string)s.CustomState == errorCode);
     }
 
-    [Fact(
-        Skip = "Disabled as part of https://eaflood.atlassian.net/browse/CDMS-685 until we better understand this rule"
-    )]
-    public void Validate_Returns_ALVSVAL401_WhenFinalisationNotCancelled_AndTheExternalVersionDoesNotMatchTheClearanceRequest()
+    [Fact]
+    public void Validate_Returns_ALVSVAL401_WhenFinalisationExternalVersionDoesNotMatchTheClearanceRequestExternalVersion()
     {
         var existingClearanceRequest = DataApiClearanceRequestFixture().With(c => c.ExternalVersion, 2).Create();
         var newFinalisation = DataApiFinalisationFixture()


### PR DESCRIPTION
We now understand that cancelled messages is not relevant for this validation check.