### PR TITLE
CDMS-704: Remove ALVSVAL308 check for no documents

### DIFF
--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -84,14 +84,6 @@ public class CommodityValidator : AbstractValidator<Commodity>
             )
             .WithState(_ => "ALVSVAL328")
             .When(x => x.Checks is not null && x.Checks.Any(y => y.CheckCode == "H224"));
-
-        // CDMS-276
-        RuleFor(p => p.Documents)
-            .NotEmpty()
-            .WithMessage(c =>
-                $"Item {c.ItemNumber} has no document code. BTMS requires at least one item document. Your request with correlation ID {correlationId} has been terminated.."
-            )
-            .WithState(_ => "ALVSVAL308");
     }
 
     private static bool IsNotAGmsCheckCode(CommodityCheck check)

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/CommodityValidatorTests.cs
@@ -55,6 +55,18 @@ public class CommodityValidatorTests
     }
 
     [Fact]
+    public void Validate_DoesNotReturn_ALVSVAL308_WhenNoDocumentsAreProvided()
+    {
+        var commodity = new Commodity { ItemNumber = 1 };
+
+        var result = _validator.TestValidate(commodity);
+
+        var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL308");
+
+        Assert.Null(error);
+    }
+
+    [Fact]
     public void Validate_Returns_ALVSVAL317_WhenTwoChecksByTheSameAuthorityAreOnTheSameCommodity()
     {
         var commodity = new Commodity
@@ -115,7 +127,6 @@ public class CommodityValidatorTests
         var commodity = new Commodity { ItemNumber = 1, Checks = [new CommodityCheck { CheckCode = "H220" }] };
 
         var result = _validator.TestValidate(commodity);
-        result.ShouldHaveValidationErrorFor(c => c.Documents);
 
         var error = result.Errors.Find(e => (string)e.CustomState == "ALVSVAL318");
 


### PR DESCRIPTION
We shouldn't be validating that no documents have been passed.