### PR TITLE
CDMS-716: Add N852 to allowed documents

### DIFF
--- a/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CommodityValidator.cs
@@ -98,16 +98,16 @@ public class CommodityValidator : AbstractValidator<Commodity>
 
     private static bool MustHaveCorrectDocumentCodesForChecks(Commodity commodity, ImportDocument importDocument)
     {
-        var checkCodes = AuthorityCodeMappings
-            .Where(x => x.DocumentCode == importDocument.DocumentCode)
+        var checkCodes = CustomsDeclarationMappings
+            .AuthorityDocumentChecks.Where(x => x.DocumentCode == importDocument.DocumentCode)
             .Select(x => x.CheckCode);
         return commodity.Checks != null && commodity.Checks.Any(x => checkCodes.Contains(x.CheckCode));
     }
 
     private static bool MustHaveDocumentForCheck(Commodity commodity, CommodityCheck check)
     {
-        var documentCodes = AuthorityCodeMappings
-            .Where(x => x.CheckCode == check.CheckCode)
+        var documentCodes = CustomsDeclarationMappings
+            .AuthorityDocumentChecks.Where(x => x.CheckCode == check.CheckCode)
             .Select(x => x.DocumentCode);
         return commodity.Documents != null && commodity.Documents.Any(x => documentCodes.Contains(x.DocumentCode));
     }
@@ -129,8 +129,8 @@ public class CommodityValidator : AbstractValidator<Commodity>
     {
         var checkCodes = checks.Select(x => x.CheckCode).Where(IsNotAnIuuCheckCode);
 
-        var multipleCheckCodeMatches = AuthorityCodeMappings
-            .Select(a => new { a.Name, a.CheckCode })
+        var multipleCheckCodeMatches = CustomsDeclarationMappings
+            .AuthorityDocumentChecks.Select(a => new { a.Name, a.CheckCode })
             .Distinct()
             .Select(a => new { a.Name, Count = checkCodes.Count(c => c == a.CheckCode) })
             .Where(a => a.Count > 1);
@@ -142,22 +142,4 @@ public class CommodityValidator : AbstractValidator<Commodity>
     {
         return checks.Any(x => x.CheckCode == "H222");
     }
-
-    public sealed record AuthorityCodeMap(string Name, string DocumentCode, string CheckCode);
-
-    public static readonly List<AuthorityCodeMap> AuthorityCodeMappings =
-    [
-        new("HMI-SMS", "N002", "H218"),
-        new("HMI-GMS", "N002", "H220"),
-        new("HMI-SMS", "C085", "H218"),
-        new("HMI-GMS", "C085", "H220"),
-        new("PHSI", "N851", "H219"),
-        new("PHSI", "9115", "H219"),
-        new("PHSI", "C085", "H219"),
-        new("PHA-IUU", "C673", "H224"),
-        new("PHA-IUU", "C641", "H224"),
-        new("PHA-POAO", "N853", "H222"),
-        new("PHA-FNAO", "C678", "H223"),
-        new("APHA", "C640", "H221"),
-    ];
 }

--- a/src/Processor/Validation/CustomsDeclarations/CustomsDeclarationMappings.cs
+++ b/src/Processor/Validation/CustomsDeclarations/CustomsDeclarationMappings.cs
@@ -1,0 +1,23 @@
+namespace Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
+
+public static class CustomsDeclarationMappings
+{
+    public sealed record AuthorityDocumentCheck(string Name, string DocumentCode, string CheckCode);
+
+    public static readonly List<AuthorityDocumentCheck> AuthorityDocumentChecks =
+    [
+        new("HMI-SMS", "N002", "H218"),
+        new("HMI-GMS", "N002", "H220"),
+        new("HMI-SMS", "C085", "H218"),
+        new("HMI-GMS", "C085", "H220"),
+        new("PHSI", "N851", "H219"),
+        new("PHSI", "9115", "H219"),
+        new("PHSI", "C085", "H219"),
+        new("PHA-IUU", "C673", "H224"),
+        new("PHA-IUU", "C641", "H224"),
+        new("PHA-POAO", "N853", "H222"),
+        new("PHA-FNAO", "N852", "H223"),
+        new("PHA-FNAO", "C678", "H223"),
+        new("APHA", "C640", "H221"),
+    ];
+}

--- a/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
+++ b/src/Processor/Validation/CustomsDeclarations/ImportDocumentValidator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using FluentValidation;
 
@@ -20,20 +21,9 @@ public class ImportDocumentValidator : AbstractValidator<ImportDocument>
         RuleFor(p => p.DocumentControl).NotEmpty().MaximumLength(1);
     }
 
-    private static readonly List<string> s_documentCodes =
-    [
-        "C085",
-        "C633",
-        "C640",
-        "C641",
-        "C673",
-        "N002",
-        "N851",
-        "N852",
-        "C678",
-        "N853",
-        "9115",
-    ];
+    private static readonly FrozenSet<string> s_documentCodes = CustomsDeclarationMappings
+        .AuthorityDocumentChecks.Select(a => a.DocumentCode)
+        .ToFrozenSet();
 
     private static bool BeAValidDocumentCode(string documentCode)
     {

--- a/tests/Processor.Tests/Validation/CustomsDeclarations/ImportDocumentValidatorTests.cs
+++ b/tests/Processor.Tests/Validation/CustomsDeclarations/ImportDocumentValidatorTests.cs
@@ -44,7 +44,7 @@ public class ImportDocumentValidatorTests
         public ImportDocumentValidatorTestData()
         {
             Add(
-                new ImportDocument { DocumentCode = "C633" },
+                new ImportDocument { DocumentCode = "N002" },
                 new ExpectedResult(nameof(ImportDocument.DocumentCode), false)
             );
             Add(

--- a/tests/TestFixtures/ClearanceRequestFixtures.cs
+++ b/tests/TestFixtures/ClearanceRequestFixtures.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using AutoFixture;
 using AutoFixture.Dsl;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations;
 using static Defra.TradeImportsProcessor.Processor.Validation.CustomsDeclarations.CommodityValidator;
 using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
 using DataApiCustomsDeclaration = Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
@@ -15,9 +16,11 @@ public static class ClearanceRequestFixtures
         return new Fixture();
     }
 
-    private static AuthorityCodeMap GetRandomDocumentCheckMap()
+    private static CustomsDeclarationMappings.AuthorityDocumentCheck GetRandomDocumentCheckMap()
     {
-        var withoutIuuDocuments = AuthorityCodeMappings.Where(d => d.CheckCode != "H224").ToList();
+        var withoutIuuDocuments = CustomsDeclarationMappings
+            .AuthorityDocumentChecks.Where(d => d.CheckCode != "H224")
+            .ToList();
 
         return withoutIuuDocuments[RandomNumberGenerator.GetInt32(0, withoutIuuDocuments.Count)];
     }


### PR DESCRIPTION
We were missing this document from the list.

This change consolidates the two lists of documents taken from btms-backend, which results in C633 being removed because it does not have an authority mapping. This has been raised and we will follow up.