### PR TITLE
Log the incoming message ID so we can determine different messages for the same MRN, CHED or GMR

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -183,7 +183,8 @@ public class CustomsDeclarationsConsumer(
         var result = received.Deserialize<T>();
         if (result == null)
             throw new CustomsDeclarationMessageException(MessageId);
-        logger.LogInformation("Received {Type} for {Mrn}", typeof(T).Name, mrn);
+
+        logger.LogInformation("Received {Type} for {Mrn} with message ID {MessageId}", typeof(T).Name, mrn, MessageId);
 
         return result;
     }

--- a/src/Processor/Consumers/GmrsConsumer.cs
+++ b/src/Processor/Consumers/GmrsConsumer.cs
@@ -47,7 +47,7 @@ public class GmrsConsumer(
             return;
         }
 
-        logger.LogInformation("Received Gmr for {GmrId}", gmr.GmrId);
+        logger.LogInformation("Received Gmr for {GmrId} with message ID {MessageId}", gmr.GmrId, MessageId);
 
         await api.PutGmr(dataApiGmr.Id!, dataApiGmr, null, cancellationToken);
     }


### PR DESCRIPTION
We have what looks like repeated consumption of the same message in DEV.

This logging will show us the message ID being processed if present.