### PR TITLE
Set 10 consumers per host across all environments

### DIFF
--- a/src/Processor/appsettings.cdp.dev.json
+++ b/src/Processor/appsettings.cdp.dev.json
@@ -2,15 +2,8 @@
   "DataApi": {
     "BaseAddress": "https://trade-imports-data-api.dev.cdp-int.defra.cloud"
   },
-  "CustomsDeclarationsConsumer": {
-    "ConsumersPerHost": 10
-  },
   "ServiceBus": {
-    "Gmrs": {
-      "ConsumersPerHost": 10
-    },
     "Notifications": {
-      "ConsumersPerHost": 10,
       "Topic": "defra.trade.imports.notification-topic",
       "Subscription": "btms"
     }

--- a/src/Processor/appsettings.json
+++ b/src/Processor/appsettings.json
@@ -26,6 +26,7 @@
     ]
   },
   "CustomsDeclarationsConsumer": {
+    "ConsumersPerHost": 10,
     "QueueName": "trade_imports_inbound_customs_declarations_processor.fifo"
   },
   "DataApi": {
@@ -33,10 +34,12 @@
   },
   "ServiceBus": {
     "Gmrs": {
+      "ConsumersPerHost": 10,
       "Topic": "defra.trade.dmp.outputgmrs.dev.1001.topic",
       "Subscription": "defra.trade.dmp.btms-ingest.dev.1001.subscription"
     },
     "Notifications": {
+      "ConsumersPerHost": 10,
       "Topic": "notification-topic",
       "Subscription": "btms"
     }


### PR DESCRIPTION
As per PR title.

Previously this was just set in DEV but we will most likely not revisit this setting and it's important in relation to other services consuming at 20 instances per host.

Therefore, set this for all environments now as our baseline.