### PR TITLE
Don't execute the auth if it's running for an endpoint that allows anonymous

### DIFF
--- a/src/Processor/Authentication/BasicAuthenticationHandler.cs
+++ b/src/Processor/Authentication/BasicAuthenticationHandler.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using Defra.TradeImportsProcessor.Processor.Configuration;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 
 namespace Defra.TradeImportsProcessor.Processor.Authentication;
@@ -21,6 +22,10 @@ public class BasicAuthenticationHandler(
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        var endpoint = Context.GetEndpoint();
+        if (endpoint?.Metadata.GetMetadata<IAllowAnonymous>() != null)
+            return NoResult();
+
         var authorizationHeader = Request.Headers.Authorization.ToString();
         if (string.IsNullOrEmpty(authorizationHeader))
             return Fail();
@@ -47,6 +52,8 @@ public class BasicAuthenticationHandler(
 
         return Success(ticket);
     }
+
+    private static Task<AuthenticateResult> NoResult() => Task.FromResult(AuthenticateResult.NoResult());
 
     private static Task<AuthenticateResult> Fail() => Task.FromResult(AuthenticateResult.Fail("Failed authorization"));
 


### PR DESCRIPTION
This PR stops the following log message from being written when a /health request is being processed, which allows anonymous access:

```
"Basic" was not authenticated. Failure message: "Failed authorization"
```