### PR TITLE
Silence volume of logs related to health endpoint calls

### DIFF
--- a/src/Processor/Utils/Logging/WebApplicationBuilderExtensions.cs
+++ b/src/Processor/Utils/Logging/WebApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.HeaderPropagation;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Serilog;
+using Serilog.Events;
 
 namespace Defra.TradeImportsProcessor.Processor.Utils.Logging;
 
@@ -57,7 +58,13 @@ public static class WebApplicationBuilderExtensions
             .ReadFrom.Configuration(hostBuilderContext.Configuration)
             .Enrich.WithEcsHttpContext(httpAccessor)
             .Enrich.FromLogContext()
-            .Enrich.With(new TraceContextEnricher());
+            .Enrich.With(new TraceContextEnricher())
+            .Filter.ByExcluding(x =>
+                x.Level == LogEventLevel.Information
+                && x.Properties.TryGetValue("RequestPath", out var path)
+                && path.ToString().Contains("/health")
+                && !x.MessageTemplate.Text.StartsWith("Request finished")
+            );
 
         if (!string.IsNullOrWhiteSpace(serviceVersion))
             config.Enrich.WithProperty("service.version", serviceVersion);


### PR DESCRIPTION
Our health check calls generate continual noise once deployed. However, we don't want to get rid of the them entirely.

This PR filters logs so we only get the following:

```
Request finished "HTTP/1.1" "GET" "http"://"localhost:8080""""/health""" - 200 null "application/json; charset=utf-8" 9.5113ms
```

Alongside any non Information logs ie errors, warnings etc related to health endpoint execution.