### PR TITLE
Remove rate limiter and circuit breaker from data API resilience pipeline

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddDataApiHttpClient(this IServiceCollection services)
     {
-        var resilienceOptions = new HttpStandardResilienceOptions();
+        var resilienceOptions = new HttpStandardResilienceOptions { Retry = { UseJitter = true } };
         resilienceOptions.Retry.DisableForUnsafeHttpMethods();
 
         services


### PR DESCRIPTION
The standard resilience handler includes two strategies we do not want by default.

A rate limiter - this protects downstream services and we do not have a rate limit currently for the data API, therefore we are removing.

A circuit breaker - similar to the above, we have no established SLA therefore a circuit breaker can introduce more harm than good when it's used unknowingly as the data API may return enough errors to open the circuit, which will prevent traffic from being sent from the processor to the data API; when in reality the data API could recover sooner than the circuit breaker allows. Therefore, for now, we are removing the circuit breaker.

I am also enabled Jitter for the retry policy as it's not a default.

All other settings are provided as defaults from the `HttpStandardResilienceOptions`.

We still do not retry unsafe methods, which includes `HttpMethod.Delete, HttpMethod.Post, HttpMethod.Put, HttpMethod.Connect, HttpMethod.Patch`.