### PR TITLE
Change Items so it's not a required field and will deserialise as an empty array

### DIFF
--- a/src/Processor/Models/CustomsDeclarations/ClearanceRequest.cs
+++ b/src/Processor/Models/CustomsDeclarations/ClearanceRequest.cs
@@ -9,7 +9,7 @@ public class ClearanceRequest : CustomsDeclarationsBase
     public required ClearanceRequestHeader Header { get; init; }
 
     [JsonPropertyName("items")]
-    public required Item[] Items { get; init; }
+    public Item[] Items { get; init; } = [];
 
     public static explicit operator DataApiCustomsDeclaration.ClearanceRequest(ClearanceRequest clearanceRequest)
     {

--- a/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Processor.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Amazon.SQS.Model;
 using AutoFixture;
 using Defra.TradeImportsDataApi.Api.Client;
-using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsProcessor.Processor.IntegrationTests.Clients;
 using Defra.TradeImportsProcessor.Processor.IntegrationTests.Helpers;
 using Defra.TradeImportsProcessor.Processor.IntegrationTests.TestBase;
@@ -16,6 +15,7 @@ using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.FinalisationFixtures;
 using static Defra.TradeImportsProcessor.TestFixtures.InboundErrorFixtures;
+using ClearanceRequest = Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations.ClearanceRequest;
 
 namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Consumers;
 
@@ -127,6 +127,47 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
                 return requests.Count == 1;
             })
         );
+    }
+
+    [Fact]
+    public async Task WhenClearanceRequestSent_ButNoItems_ThenClearanceRequestIsProcessedAndSentToTheDataApi()
+    {
+        var mrn = GenerateMrn();
+        var clearanceRequest = ClearanceRequestFixture(mrn).Create();
+
+        var createPath = $"/customs-declarations/{mrn}";
+        var mappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        mappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingPut().WithPath(createPath))
+                .WithResponse(rsp => rsp.WithStatusCode(HttpStatusCode.Created))
+        );
+        var status = await mappingBuilder.BuildAndPostAsync();
+        Assert.NotNull(status.Guid);
+
+        var errorEndpointWasNotCalled = await WithProcessingErrorEndpoint(mrn);
+
+        var body = JsonSerializer.Serialize(
+            clearanceRequest,
+#pragma warning disable CA1869
+            new JsonSerializerOptions
+#pragma warning restore CA1869
+            {
+                Converters = { new ExcludePropertyJsonConverter<ClearanceRequest>(nameof(ClearanceRequest.Items)) },
+            }
+        );
+
+        await SendMessage(mrn, body, WithInboundHmrcMessageType(InboundHmrcMessageType.ClearanceRequest));
+
+        Assert.True(
+            await AsyncWaiter.WaitForAsync(async () =>
+            {
+                var requestsModel = new RequestModel { Methods = ["PUT"], Path = createPath };
+                var requests = await _wireMockAdminApi.FindRequestsAsync(requestsModel);
+                return requests.Count == 1;
+            })
+        );
+
+        await errorEndpointWasNotCalled();
     }
 
     [Fact]

--- a/tests/Processor.IntegrationTests/Helpers/ExcludePropertyJsonConverter.cs
+++ b/tests/Processor.IntegrationTests/Helpers/ExcludePropertyJsonConverter.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Helpers;
+
+public class ExcludePropertyJsonConverter<T>(params string[] propertyNames) : JsonConverter<T>
+{
+    private readonly HashSet<string> _propertiesToExclude = new(propertyNames, StringComparer.OrdinalIgnoreCase);
+
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions? options)
+    {
+        return JsonSerializer.Deserialize<T>(ref reader, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (var property in typeof(T).GetProperties())
+        {
+            if (_propertiesToExclude.Contains(property.Name))
+                continue;
+
+            var propertyValue = property.GetValue(value);
+
+            var propertyName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
+
+            if (propertyValue != null)
+            {
+                writer.WritePropertyName(propertyName);
+                JsonSerializer.Serialize(writer, propertyValue, property.PropertyType, options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
We saw a deserialisation error:

```
System.Text.Json.JsonException: JSON deserialization for type 'Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations.ClearanceRequest' was missing required properties including: 'items'.
   at void System.Text.Json.ThrowHelper.ThrowJsonException_JsonRequiredPropertyMissing(JsonTypeInfo parent, BitArray requiredPropertiesSet)
   at bool System.Text.Json.Serialization.Converters.ObjectDefaultConverter<T>.OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out T value)
   at bool System.Text.Json.Serialization.JsonConverter<T>.TryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out T value, out bool isPopulatedValue)
   at bool System.Text.Json.Serialization.JsonConverter<T>.ReadCore(ref Utf8JsonReader reader, out T value, JsonSerializerOptions options, ref ReadStack state)
   at async Task<ValueTuple<CustomsDeclaration, ValidationResult>> Defra.TradeImportsProcessor.Processor.Consumers.CustomsDeclarationsConsumer.OnHandleClearanceRequest(string mrn, JsonElement received, CustomsDeclarationResponse existingCustomsDeclaration, CancellationToken cancellationToken) in /src/src/Processor/Consumers/CustomsDeclarationsConsumer.cs:line 195
   at async Task Defra.TradeImportsProcessor.Processor.Consumers.CustomsDeclarationsConsumer.OnHandle(JsonElement received, CancellationToken cancellationToken) in /src/src/Processor/Consumers/CustomsDeclarationsConsumer.cs:line 124
   at async Task<object> SlimMessageBus.Host.MessageHandler.ExecuteConsumer(object message, IConsumerContext consumerContext, IMessageTypeConsumerInvokerSettings consumerInvoker, Type responseType)
   at async Task<object> SlimMessageBus.Host.ConsumerInterceptorPipeline.Next<TResponse>()
   at async Task<object> Defra.TradeImportsProcessor.Processor.Metrics.MetricsInterceptor<TMessage>.OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context) in /src/src/Processor/Metrics/MetricsInterceptor.cs:line 20
   at async Task<object> SlimMessageBus.Host.ConsumerInterceptorPipeline.Next<TResponse>()
   at async Task<object> Defra.TradeImportsProcessor.Processor.Utils.Logging.LoggingInterceptor<TMessage>.OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context) in /src/src/Processor/Utils/Logging/LoggingInterceptor.cs:line 20
```

The clearance request was received with no items. Therefore we should let it through and standard validation will kick in.