### PR TITLE
Add replay endpoints for customs declarations and finalisations

### DIFF
--- a/Defra.TradeImportsProcessor.sln.DotSettings
+++ b/Defra.TradeImportsProcessor.sln.DotSettings
@@ -1,5 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=alvs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=finalisations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ipaffs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Processor/Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/Processor/Endpoints/EndpointRouteBuilderExtensions.cs
@@ -1,8 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
+using Amazon.SQS.Model;
+using Defra.TradeImportsProcessor.Processor.Consumers;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using Microsoft.AspNetCore.Mvc;
 using SlimMessageBus;
+using SlimMessageBus.Host;
 
 namespace Defra.TradeImportsProcessor.Processor.Endpoints;
 
@@ -12,30 +16,79 @@ public static class EndpointRouteBuilderExtensions
     public static void MapReplayEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapPost("replay/import-pre-notifications", ReplayImportPreNotifications).RequireAuthorization();
+        app.MapPost("replay/clearance-requests", ReplayClearanceRequests).RequireAuthorization();
+        app.MapPost("replay/finalisations", ReplayFinalisations).RequireAuthorization();
     }
 
     [HttpPost]
     private static async Task<IResult> ReplayImportPreNotifications(
         HttpRequest request,
-        [FromServices] IConsumer<JsonElement> notificationConsumer,
+        [FromServices] NotificationConsumer consumer,
+        [FromBody] JsonElement body,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken
+    ) => await HandleMessage(consumer, body, loggerFactory, cancellationToken);
+
+    [HttpPost]
+    private static async Task<IResult> ReplayClearanceRequests(
+        HttpRequest request,
+        [FromServices] CustomsDeclarationsConsumer consumer,
         [FromBody] JsonElement body,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken cancellationToken
     )
     {
+        consumer.Context = CreateContext(InboundHmrcMessageType.ClearanceRequest);
+
+        return await HandleMessage(consumer, body, loggerFactory, cancellationToken);
+    }
+
+    [HttpPost]
+    private static async Task<IResult> ReplayFinalisations(
+        HttpRequest request,
+        [FromServices] CustomsDeclarationsConsumer consumer,
+        [FromBody] JsonElement body,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken
+    )
+    {
+        consumer.Context = CreateContext(InboundHmrcMessageType.Finalisation);
+
+        return await HandleMessage(consumer, body, loggerFactory, cancellationToken);
+    }
+
+    private static async Task<IResult> HandleMessage(
+        IConsumer<JsonElement> consumer,
+        JsonElement body,
+        ILoggerFactory loggerFactory,
+        CancellationToken cancellationToken
+    )
+    {
         try
         {
-            await notificationConsumer.OnHandle(body, cancellationToken);
+            await consumer.OnHandle(body, cancellationToken);
         }
         catch (HttpRequestException httpRequestException)
             when (httpRequestException.StatusCode == HttpStatusCode.Conflict)
         {
-            var logger = loggerFactory.CreateLogger(nameof(ReplayImportPreNotifications));
+            var logger = loggerFactory.CreateLogger(nameof(HandleMessage));
             logger.LogWarning(httpRequestException, "409 Conflict");
 
             return Results.Conflict();
         }
 
         return Results.Accepted();
+    }
+
+    private static ConsumerContext CreateContext(string messageType)
+    {
+        return new ConsumerContext
+        {
+            Headers = new Dictionary<string, object> { { "InboundHmrcMessageType", messageType } }.AsReadOnly(),
+            Properties =
+            {
+                new KeyValuePair<string, object>("Sqs_Message", new Message { MessageId = Guid.NewGuid().ToString() }),
+            },
+        };
     }
 }

--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -69,8 +69,6 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddConsumers(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddTransient<IConsumer<JsonElement>, NotificationConsumer>();
-
         var customsDeclarationsConsumerOptions = services
             .AddValidateOptions<CustomsDeclarationsConsumerOptions>(
                 configuration,
@@ -155,6 +153,10 @@ public static class ServiceCollectionExtensions
                 }
             );
         });
+
+        // Concrete consumers added for temporary replay endpoints
+        services.AddTransient<NotificationConsumer>();
+        services.AddTransient<CustomsDeclarationsConsumer>();
 
         return services;
     }

--- a/tests/Processor.IntegrationTests/Endpoints/ReplayClearanceRequestsEndpointTests.cs
+++ b/tests/Processor.IntegrationTests/Endpoints/ReplayClearanceRequestsEndpointTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using AutoFixture;
+using Defra.TradeImportsProcessor.Processor.IntegrationTests.Clients;
+using Defra.TradeImportsProcessor.Processor.IntegrationTests.Helpers;
+using FluentAssertions;
+using WireMock.Admin.Mappings;
+using WireMock.Client;
+using WireMock.Client.Extensions;
+using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
+using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
+
+namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Endpoints;
+
+[Collection("UsesWireMockClient")]
+public class ReplayClearanceRequestsEndpointTests(WireMockClient wireMockClient)
+{
+    private readonly IWireMockAdminApi _wireMockAdminApi = wireMockClient.WireMockAdminApi;
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri("http://localhost:8080");
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            "TWVzc2FnZVJlcGxheTpyZXBsYXktbWVzc2FnZQ=="
+        );
+        return httpClient;
+    }
+
+    [Fact]
+    public async Task WhenPostingAClearanceRequest_ItIsHandled()
+    {
+        var mrn = GenerateMrn();
+        var clearanceRequest = ClearanceRequestFixture(mrn).Create();
+        var content = JsonSerializer.Serialize(clearanceRequest);
+        var body = new StringContent(content, Encoding.UTF8, "application/json");
+
+        var createPath = $"/customs-declarations/{mrn}";
+        var mappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        mappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingPut().WithPath(createPath))
+                .WithResponse(rsp => rsp.WithStatusCode(HttpStatusCode.Created))
+        );
+        var status = await mappingBuilder.BuildAndPostAsync();
+        Assert.NotNull(status.Guid);
+
+        const string traceHeader = "x-cdp-request-id";
+        var traceId = Guid.NewGuid().ToString("N");
+        var httpClient = CreateHttpClient();
+        httpClient.DefaultRequestHeaders.Add(traceHeader, traceId);
+        var response = await httpClient.PostAsync("/replay/clearance-requests", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        Assert.True(
+            await AsyncWaiter.WaitForAsync(async () =>
+            {
+                try
+                {
+                    var requestModel = new RequestModel { Methods = ["PUT"], Path = createPath };
+                    var requests = (await _wireMockAdminApi.FindRequestsAsync(requestModel)).Where(x =>
+                        x.Request.Headers != null
+                        && x.Request.Headers.ContainsKey(traceHeader)
+                        && x.Request.Headers.TryGetValue(traceHeader, out var list)
+                        && list.Contains(traceId)
+                    );
+                    return requests.Count() == 1;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            })
+        );
+    }
+
+    [Fact]
+    public async Task WhenPostingAnInvalidBody_ItReturnsBadRequest()
+    {
+        var body = new StringContent("sosig", Encoding.UTF8, "application/json");
+        var httpClient = CreateHttpClient();
+        var response = await httpClient.PostAsync("/replay/clearance-requests", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task WhenPostingAnInvalidClearanceRequest_ItReturnsAnError()
+    {
+        var body = new StringContent("{}", Encoding.UTF8, "application/json");
+        var httpClient = CreateHttpClient();
+        var response = await httpClient.PostAsync("/replay/clearance-requests", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+}

--- a/tests/Processor.IntegrationTests/Endpoints/ReplayFinalisationsEndpointTests.cs
+++ b/tests/Processor.IntegrationTests/Endpoints/ReplayFinalisationsEndpointTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using AutoFixture;
+using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsProcessor.Processor.IntegrationTests.Clients;
+using Defra.TradeImportsProcessor.Processor.IntegrationTests.Helpers;
+using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
+using FluentAssertions;
+using WireMock.Admin.Mappings;
+using WireMock.Client;
+using WireMock.Client.Extensions;
+using static Defra.TradeImportsProcessor.TestFixtures.ClearanceRequestFixtures;
+using static Defra.TradeImportsProcessor.TestFixtures.CustomsDeclarationFixtures;
+using static Defra.TradeImportsProcessor.TestFixtures.FinalisationFixtures;
+
+namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Endpoints;
+
+[Collection("UsesWireMockClient")]
+public class ReplayFinalisationsEndpointTests(WireMockClient wireMockClient)
+{
+    private readonly IWireMockAdminApi _wireMockAdminApi = wireMockClient.WireMockAdminApi;
+
+    private static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri("http://localhost:8080");
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            "TWVzc2FnZVJlcGxheTpyZXBsYXktbWVzc2FnZQ=="
+        );
+        return httpClient;
+    }
+
+    [Fact]
+    public async Task WhenPostingAFinalisation_ItIsHandled()
+    {
+        var mrn = GenerateMrn();
+        var clearanceRequest = DataApiClearanceRequestFixture().Create();
+        var finalisationHeader = FinalisationHeaderFixture((int)clearanceRequest.ExternalVersion!, mrn)
+            .With(h => h.FinalState, ((int)FinalStateValues.Cleared).ToString())
+            .Create();
+        var finalisation = FinalisationFixture(mrn).With(f => f.Header, finalisationHeader).Create();
+        var content = JsonSerializer.Serialize(finalisation);
+        var body = new StringContent(content, Encoding.UTF8, "application/json");
+
+        var getCustomsDeclarationResponse = new CustomsDeclarationResponse(
+            mrn,
+            clearanceRequest,
+            null,
+            null,
+            null,
+            DateTime.Now,
+            DateTime.Now,
+            "12345"
+        );
+
+        var createPath = $"/customs-declarations/{mrn}";
+        var getMappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        getMappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingGet().WithPath(createPath))
+                .WithResponse(rsp =>
+                {
+                    rsp.WithBody(JsonSerializer.Serialize(getCustomsDeclarationResponse));
+                    rsp.WithStatusCode(HttpStatusCode.OK);
+                })
+        );
+        var getMappingBuilderResult = await getMappingBuilder.BuildAndPostAsync();
+        Assert.Null(getMappingBuilderResult.Error);
+
+        var putMappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        putMappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingPut().WithPath(createPath))
+                .WithResponse(rsp => rsp.WithStatusCode(HttpStatusCode.Created))
+        );
+        var putMappingBuilderResult = await putMappingBuilder.BuildAndPostAsync();
+        Assert.Null(putMappingBuilderResult.Error);
+
+        const string traceHeader = "x-cdp-request-id";
+        var traceId = Guid.NewGuid().ToString("N");
+        var httpClient = CreateHttpClient();
+        httpClient.DefaultRequestHeaders.Add(traceHeader, traceId);
+        var response = await httpClient.PostAsync("/replay/finalisations", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        Assert.True(
+            await AsyncWaiter.WaitForAsync(async () =>
+            {
+                try
+                {
+                    var requestModel = new RequestModel { Methods = ["PUT"], Path = createPath };
+                    var requests = (await _wireMockAdminApi.FindRequestsAsync(requestModel)).Where(x =>
+                        x.Request.Headers != null
+                        && x.Request.Headers.ContainsKey(traceHeader)
+                        && x.Request.Headers.TryGetValue(traceHeader, out var list)
+                        && list.Contains(traceId)
+                    );
+                    return requests.Count() == 1;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            })
+        );
+    }
+
+    [Fact]
+    public async Task WhenPostingAnInvalidBody_ItReturnsBadRequest()
+    {
+        var body = new StringContent("sosig", Encoding.UTF8, "application/json");
+        var httpClient = CreateHttpClient();
+        var response = await httpClient.PostAsync("/replay/finalisations", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task WhenPostingAnInvalidFinalisation_ItReturnsAnError()
+    {
+        var body = new StringContent("{}", Encoding.UTF8, "application/json");
+        var httpClient = CreateHttpClient();
+        var response = await httpClient.PostAsync("/replay/finalisations", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+}

--- a/tests/Processor.IntegrationTests/Endpoints/ReplayImportPreNotificationEndpointTests.cs
+++ b/tests/Processor.IntegrationTests/Endpoints/ReplayImportPreNotificationEndpointTests.cs
@@ -14,7 +14,7 @@ using static Defra.TradeImportsProcessor.TestFixtures.ImportNotificationFixtures
 namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.Endpoints;
 
 [Collection("UsesWireMockClient")]
-public class ReplayImportPreNotificationEndpointsTests(WireMockClient wireMockClient)
+public class ReplayImportPreNotificationEndpointTests(WireMockClient wireMockClient)
 {
     private readonly IWireMockAdminApi _wireMockAdminApi = wireMockClient.WireMockAdminApi;
 


### PR DESCRIPTION
As per PR title.

We're now sending clearance requests and finalisations from the message replay service directly, as we want to isolate the gateway and not affect it with unnecessary replay traffic when it's live. 

The gateway is also configured not to send traffic to the BTMS stack so we couldn't use it anyway without deploying a new version and our downstream services might not be in full service.

Consumers are transient so they're new instances on each request. 

The endpoint then sets the context on each new consumer with a fake message ID.