### PR TITLE
Add ResourceId from message being consumed if present

### DIFF
--- a/src/Processor/Extensions/ConsumerContextExtensions.cs
+++ b/src/Processor/Extensions/ConsumerContextExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Amazon.SQS.Model;
 using Azure.Messaging.ServiceBus;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
@@ -5,13 +6,16 @@ using SlimMessageBus;
 
 namespace Defra.TradeImportsProcessor.Processor.Extensions;
 
+[ExcludeFromCodeCoverage]
 public static class MessageBusHeaders
 {
     public const string InboundHmrcMessageTypeHeader = "InboundHmrcMessageType";
     public const string SqsBusMessage = "Sqs_Message";
     public const string ServiceBusMessage = "ServiceBus_Message";
+    public const string ResourceId = "ResourceId";
 }
 
+[ExcludeFromCodeCoverage]
 public static class ConsumerContextExtensions
 {
     public static string GetMessageId(this IConsumerContext consumerContext)
@@ -37,5 +41,15 @@ public static class ConsumerContextExtensions
         }
 
         return nameof(ImportPreNotification);
+    }
+
+    public static string GetResourceId(this IConsumerContext consumerContext)
+    {
+        if (consumerContext.Headers.TryGetValue(MessageBusHeaders.ResourceId, out var value))
+        {
+            return value.ToString()!;
+        }
+
+        return string.Empty;
     }
 }

--- a/src/Processor/Utils/Logging/LoggingInterceptor.cs
+++ b/src/Processor/Utils/Logging/LoggingInterceptor.cs
@@ -13,7 +13,8 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
     public async Task<object> OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context)
     {
         var messageId = context.GetMessageId();
-        logger.LogInformation("Processing MessageId {MessageId}", messageId);
+        var resourceId = context.GetResourceId();
+        logger.LogInformation("Processing message {MessageId} for resource {ResourceId}", messageId, resourceId);
 
         try
         {
@@ -22,12 +23,22 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
         catch (HttpRequestException httpRequestException)
             when (httpRequestException.StatusCode == HttpStatusCode.Conflict)
         {
-            logger.LogWarning(httpRequestException, "409 Conflict Processing MessageId {MessageId}", messageId);
+            logger.LogWarning(
+                httpRequestException,
+                "409 Conflict processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
             throw;
         }
         catch (Exception exception)
         {
-            logger.LogError(exception, "Error Processing MessageId {MessageId}", messageId);
+            logger.LogError(
+                exception,
+                "Error processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
             throw;
         }
     }


### PR DESCRIPTION
As per PR title.

If the message being consumed contains a header for ResourceId it will be included in the log.