### PR TITLE
Check logs related to PRR and include ECS formatter in bootstrapper logger

### DIFF
--- a/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
+++ b/src/Processor/Consumers/CustomsDeclarationsConsumer.cs
@@ -115,6 +115,7 @@ public class CustomsDeclarationsConsumer(
                 inboundHmrcMessageType,
                 cancellationToken
             );
+
             return;
         }
 
@@ -153,6 +154,7 @@ public class CustomsDeclarationsConsumer(
                 inboundHmrcMessageType,
                 cancellationToken
             );
+
             return;
         }
 
@@ -164,6 +166,7 @@ public class CustomsDeclarationsConsumer(
             existingCustomsDeclaration != null ? "Updating" : "Creating",
             mrn
         );
+
         await api.PutCustomsDeclaration(
             mrn,
             updatedCustomsDeclaration,
@@ -180,6 +183,7 @@ public class CustomsDeclarationsConsumer(
         var result = received.Deserialize<T>();
         if (result == null)
             throw new CustomsDeclarationMessageException(MessageId);
+
         logger.LogInformation("Received {Type} for {Mrn}", typeof(T).Name, mrn);
 
         return result;
@@ -266,6 +270,7 @@ public class CustomsDeclarationsConsumer(
         if (existingCustomsDeclaration?.ClearanceRequest == null)
         {
             logger.LogInformation("Skipping finalisation of {Mrn} because no clearance request exists", mrn);
+
             return (null, null);
         }
 

--- a/src/Processor/Program.cs
+++ b/src/Processor/Program.cs
@@ -6,10 +6,11 @@ using Defra.TradeImportsProcessor.Processor.Metrics;
 using Defra.TradeImportsProcessor.Processor.Utils;
 using Defra.TradeImportsProcessor.Processor.Utils.Http;
 using Defra.TradeImportsProcessor.Processor.Utils.Logging;
+using Elastic.CommonSchema.Serilog;
 using Microsoft.AspNetCore.Diagnostics;
 using Serilog;
 
-Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger();
+Log.Logger = new LoggerConfiguration().WriteTo.Console(new EcsTextFormatter()).CreateBootstrapLogger();
 
 try
 {

--- a/src/Processor/Utils/Http/Proxy.cs
+++ b/src/Processor/Utils/Http/Proxy.cs
@@ -22,6 +22,7 @@ public static class Proxy
         {
             var options = sp.GetRequiredService<IOptions<CdpOptions>>();
             var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger(ProxyClient);
+
             return CreateProxy(options.Value.CdpHttpsProxy, logger);
         });
     }

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -17,6 +17,18 @@ public class NotificationConsumerTests
     private readonly ILogger<NotificationConsumer> _mockLogger = Substitute.For<ILogger<NotificationConsumer>>();
 
     [Fact]
+    public async Task OnHandle_WhenImportNotificationReceived_AndDoesNotDeserialize_ThenItThrows()
+    {
+        var consumer = new NotificationConsumer(_mockLogger, _mockApi);
+
+        var act = async () => await consumer.OnHandle(JsonDocument.Parse("null").RootElement, _cancellationToken);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .And.Message.Should()
+            .Be("Received invalid message, deserialised as null");
+    }
+
+    [Fact]
     public async Task OnHandle_WhenImportNotificationReceived_AndNoImportNotificationExistsInTheDataApi_ThenItIsCreated()
     {
         var consumer = new NotificationConsumer(_mockLogger, _mockApi);


### PR DESCRIPTION
Minimal change but all logs have been reviewed against PII and message clarity etc from a support standpoint.

Adding the ECS formatter for the bootstrapper logger created during startup so if any logs from it make their way into CDP, then they will not be marked as broken due to not following the ECS format.