### PR TITLE
CDMS-554 - Add AutoStartConsumers option to config

### DIFF
--- a/src/Processor/Configuration/CustomsDeclarationsConsumerOptions.cs
+++ b/src/Processor/Configuration/CustomsDeclarationsConsumerOptions.cs
@@ -7,6 +7,9 @@ public class CustomsDeclarationsConsumerOptions
     public const string SectionName = "CustomsDeclarationsConsumer";
 
     [Required]
+    public required bool AutoStartConsumers { get; init; }
+
+    [Required]
     public required string QueueName { get; init; }
 
     public int ConsumersPerHost { get; init; } = 20;

--- a/src/Processor/Configuration/ServiceBusOptions.cs
+++ b/src/Processor/Configuration/ServiceBusOptions.cs
@@ -22,6 +22,9 @@ public class ServiceBusOptions
 public class ServiceBusSubscriptionOptions
 {
     [Required]
+    public required bool AutoStartConsumers { get; init; }
+
+    [Required]
     public required string ConnectionString { get; init; }
 
     [Required]

--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -13,7 +13,6 @@ using FluentValidation;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Polly;
-using SlimMessageBus;
 using SlimMessageBus.Host;
 using SlimMessageBus.Host.AmazonSQS;
 using SlimMessageBus.Host.AzureServiceBus;
@@ -103,13 +102,14 @@ public static class ServiceCollectionExtensions
                     );
                     mbb.AddJsonSerializer();
                     mbb.AddServicesFromAssemblyContaining<GmrsConsumer>();
-                    mbb.Consume<JsonElement>(x =>
-                    {
-                        x.Topic(serviceBusOptions.Gmrs.Topic)
-                            .SubscriptionName(serviceBusOptions.Gmrs.Subscription)
-                            .WithConsumer<GmrsConsumer>()
-                            .Instances(serviceBusOptions.Gmrs.ConsumersPerHost);
-                    });
+                    mbb.AutoStartConsumersEnabled(serviceBusOptions.Gmrs.AutoStartConsumers)
+                        .Consume<JsonElement>(x =>
+                        {
+                            x.Topic(serviceBusOptions.Gmrs.Topic)
+                                .SubscriptionName(serviceBusOptions.Gmrs.Subscription)
+                                .WithConsumer<GmrsConsumer>()
+                                .Instances(serviceBusOptions.Gmrs.ConsumersPerHost);
+                        });
                 }
             );
 
@@ -124,13 +124,14 @@ public static class ServiceCollectionExtensions
                         )
                     );
                     mbb.AddJsonSerializer();
-                    mbb.Consume<JsonElement>(x =>
-                    {
-                        x.Topic(serviceBusOptions.Notifications.Topic)
-                            .SubscriptionName(serviceBusOptions.Notifications.Subscription)
-                            .WithConsumer<NotificationConsumer>()
-                            .Instances(serviceBusOptions.Notifications.ConsumersPerHost);
-                    });
+                    mbb.AutoStartConsumersEnabled(serviceBusOptions.Notifications.AutoStartConsumers)
+                        .Consume<JsonElement>(x =>
+                        {
+                            x.Topic(serviceBusOptions.Notifications.Topic)
+                                .SubscriptionName(serviceBusOptions.Notifications.Subscription)
+                                .WithConsumer<NotificationConsumer>()
+                                .Instances(serviceBusOptions.Notifications.ConsumersPerHost);
+                        });
                 }
             );
 
@@ -148,11 +149,12 @@ public static class ServiceCollectionExtensions
                     });
                     mbb.AddJsonSerializer();
                     mbb.AddServicesFromAssemblyContaining<CustomsDeclarationsConsumer>();
-                    mbb.Consume<JsonElement>(x =>
-                        x.WithConsumer<CustomsDeclarationsConsumer>()
-                            .Queue(customsDeclarationsConsumerOptions.QueueName)
-                            .Instances(customsDeclarationsConsumerOptions.ConsumersPerHost)
-                    );
+                    mbb.AutoStartConsumersEnabled(customsDeclarationsConsumerOptions.AutoStartConsumers)
+                        .Consume<JsonElement>(x =>
+                            x.WithConsumer<CustomsDeclarationsConsumer>()
+                                .Queue(customsDeclarationsConsumerOptions.QueueName)
+                                .Instances(customsDeclarationsConsumerOptions.ConsumersPerHost)
+                        );
                 }
             );
         });

--- a/src/Processor/appsettings.cdp.prod.json
+++ b/src/Processor/appsettings.cdp.prod.json
@@ -1,13 +1,18 @@
 {
+  "CustomsDeclarationsConsumer": {
+    "AutoStartConsumers": false
+  },
   "DataApi": {
     "BaseAddress": "https://trade-imports-data-api.prod.cdp-int.defra.cloud"
   },
   "ServiceBus": {
     "Gmrs": {
+      "AutoStartConsumers": false,
       "Topic": "defra.trade.dmp.outputgmrs.prd.1001.topic",
       "Subscription": "defra.trade.dmp.btms-ingest.prd.1001.subscription"
     },
     "Notifications": {
+      "AutoStartConsumers": false,
       "Topic": "notification-topic",
       "Subscription": "btms"
     }

--- a/src/Processor/appsettings.json
+++ b/src/Processor/appsettings.json
@@ -24,6 +24,7 @@
     ]
   },
   "CustomsDeclarationsConsumer": {
+    "AutoStartConsumers": true,
     "ConsumersPerHost": 10,
     "QueueName": "trade_imports_inbound_customs_declarations_processor.fifo"
   },
@@ -32,11 +33,13 @@
   },
   "ServiceBus": {
     "Gmrs": {
+      "AutoStartConsumers": true,  
       "ConsumersPerHost": 10,
       "Topic": "defra.trade.dmp.outputgmrs.dev.1001.topic",
       "Subscription": "defra.trade.dmp.btms-ingest.dev.1001.subscription"
     },
     "Notifications": {
+      "AutoStartConsumers": true,
       "ConsumersPerHost": 10,
       "Topic": "notification-topic",
       "Subscription": "btms"

--- a/tests/Processor.Tests/Consumers/AzureConsumerErrorHandlerTests.cs
+++ b/tests/Processor.Tests/Consumers/AzureConsumerErrorHandlerTests.cs
@@ -96,12 +96,14 @@ public class AzureConsumerErrorHandlerTests
             {
                 Gmrs = new ServiceBusSubscriptionOptions
                 {
+                    AutoStartConsumers = true,
                     ConnectionString = nameof(ServiceBusSubscriptionOptions.ConnectionString),
                     Topic = nameof(ServiceBusSubscriptionOptions.Topic),
                     Subscription = nameof(ServiceBusSubscriptionOptions.Subscription),
                 },
                 Notifications = new ServiceBusSubscriptionOptions
                 {
+                    AutoStartConsumers = true,
                     ConnectionString = nameof(ServiceBusSubscriptionOptions.ConnectionString),
                     Topic = nameof(ServiceBusSubscriptionOptions.Topic),
                     Subscription = nameof(ServiceBusSubscriptionOptions.Subscription),


### PR DESCRIPTION
To prevent SQS / Azure service bus message consumption from automatically starting.

The services can be deployed to any given environment and then message consumption can be switched on once the initial due diligence has taken place 