### PR TITLE
Planned crossing - local date time of departure appears to be nullable based on production observations

### DIFF
--- a/src/Processor/Models/Gmrs/GmrPlannedCrossing.cs
+++ b/src/Processor/Models/Gmrs/GmrPlannedCrossing.cs
@@ -2,6 +2,6 @@ namespace Defra.TradeImportsProcessor.Processor.Models.Gmrs;
 
 public class GmrPlannedCrossing
 {
-    public DateTime LocalDateTimeOfDeparture { get; init; }
+    public DateTime? LocalDateTimeOfDeparture { get; init; }
     public string? RouteId { get; init; }
 }

--- a/tests/Processor.Tests/Models/GmrTests.Gmr_DeserializesCorrectly_PlannedCrossing_Departure_Nullable.verified.txt
+++ b/tests/Processor.Tests/Models/GmrTests.Gmr_DeserializesCorrectly_PlannedCrossing_Departure_Nullable.verified.txt
@@ -1,0 +1,37 @@
+﻿{
+  GmrId: GMRAADYA9J8G,
+  HaulierEori: GB1196193155298,
+  State: OPEN,
+  UpdatedDateTime: 2025-04-18 19:00:00.353 Utc,
+  Direction: UK_INBOUND,
+  HaulierType: NATO_MOD,
+  IsUnaccompanied: true,
+  VehicleRegNum: RXPXOW,
+  TrailerRegistrationNums: [
+    7PIHPW,
+    E4FWLP
+  ],
+  PlannedCrossing: {
+    RouteId: 19
+  },
+  CheckedInCrossing: {
+    LocalDateTimeOfArrival: 2025-04-28 19:00,
+    RouteId: 19
+  },
+  ActualCrossing: {
+    LocalDateTimeOfArrival: 2025-04-28 19:00,
+    RouteId: 19
+  },
+  Declarations: {
+    Customs: [
+      {
+        Id: ALVSCDSSTAND9930082
+      }
+    ],
+    Transits: [
+      {
+        Id: ABCD
+      }
+    ]
+  }
+}

--- a/tests/Processor.Tests/Models/GmrTests.cs
+++ b/tests/Processor.Tests/Models/GmrTests.cs
@@ -60,6 +60,57 @@ public class GmrTests
     }
 
     [Fact]
+    public async Task Gmr_DeserializesCorrectly_PlannedCrossing_Departure_Nullable()
+    {
+        const string gmr = """
+            {
+              "GmrId": "GMRAADYA9J8G",
+              "HaulierEori": "GB1196193155298",
+              "State": "OPEN",
+              "InspectionRequired": null,
+              "ReportToLocations": null,
+              "UpdatedDateTime": "2025-04-18T19:00:00.353Z",
+              "Direction": "UK_INBOUND",
+              "HaulierType": "NATO_MOD",
+              "IsUnaccompanied": true,
+              "VehicleRegNum": "RXPXOW",
+              "TrailerRegistrationNums": [
+                "7PIHPW",
+                "E4FWLP"
+              ],
+              "ContainerReferenceNums": null,
+              "ActualCrossing": {
+                "LocalDateTimeOfArrival": "2025-04-28T19:00",
+                "RouteId": "19"
+              },
+              "CheckedInCrossing": {
+                "LocalDateTimeOfArrival": "2025-04-28T19:00",
+                "RouteId": "19"
+              },
+              "PlannedCrossing": {
+                "LocalDateTimeOfDeparture": null,
+                "RouteId": "19"
+              },
+              "Declarations": {
+                "Transits": [
+                  {
+                    "Id": "ABCD"
+                  }
+                ],
+                "Customs": [
+                  {
+                    "Id": "ALVSCDSSTAND9930082"
+                  }
+                ]
+              }
+            }
+            """;
+
+        var deserializedGmr = JsonSerializer.Deserialize<Gmr>(gmr)!;
+        await Verify(deserializedGmr).DontScrubDateTimes();
+    }
+
+    [Fact]
     public async Task Gmr_ConversionToDataApiGmr_IsCorrect()
     {
         var timestamp = new DateTime(2025, 04, 15, 12, 0, 0, DateTimeKind.Utc);


### PR DESCRIPTION
As per PR title.

A lot of deserialisation errors were observed in production, therefore we allow the planned crossing local date time of departure field to be nullable.