### PR TITLE
Track the DLQ count for each Azure topic by peeking the messages

### DIFF
--- a/src/Processor/Consumers/AzureConsumerErrorHandler.cs
+++ b/src/Processor/Consumers/AzureConsumerErrorHandler.cs
@@ -1,7 +1,5 @@
 using System.Text.Json;
 using Defra.TradeImportsProcessor.Processor.Configuration;
-using Defra.TradeImportsProcessor.Processor.Extensions;
-using Defra.TradeImportsProcessor.Processor.Metrics;
 using Microsoft.Extensions.Options;
 using SlimMessageBus;
 using SlimMessageBus.Host;
@@ -10,7 +8,6 @@ using SlimMessageBus.Host.AzureServiceBus;
 namespace Defra.TradeImportsProcessor.Processor.Consumers;
 
 public class AzureConsumerErrorHandler<T>(
-    IConsumerMetrics consumerMetrics,
     IOptions<ServiceBusOptions> options,
     ILogger<AzureConsumerErrorHandler<T>> logger
 ) : ServiceBusConsumerErrorHandler<T>
@@ -31,28 +28,14 @@ public class AzureConsumerErrorHandler<T>(
         {
             logger.LogWarning("Dead letter message early due to JSON deserialisation exception");
 
-            DeadLetterMetric(consumerContext, jsonException);
-
             return Task.FromResult(DeadLetter());
         }
 
         if (attempts >= options.Value.AttemptsDeadLetterTolerance)
         {
             logger.LogWarning("Max attempts reached, dead lettering message");
-
-            DeadLetterMetric(consumerContext, exception);
         }
 
         return Task.FromResult(ProcessResult.Failure);
-    }
-
-    private void DeadLetterMetric(IConsumerContext consumerContext, Exception exception)
-    {
-        consumerMetrics.DeadLetter(
-            consumerContext.Path,
-            consumerContext.Consumer.GetType().Name,
-            consumerContext.GetResourceType(),
-            exception
-        );
     }
 }

--- a/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
+++ b/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
@@ -7,26 +7,32 @@ namespace Defra.TradeImportsProcessor.Processor.Metrics;
 
 public class AzureDeadLetterBackgroundService : BackgroundService
 {
-    private readonly TimeSpan _startDelay = TimeSpan.FromSeconds(60);
-    private readonly TimeSpan _delay = TimeSpan.FromSeconds(30);
+    private readonly TimeSpan _delay = TimeSpan.FromMinutes(5);
     private readonly ServiceBusSubscriptionOptions _options;
+    private readonly string _consumerName;
     private readonly ILogger<AzureDeadLetterBackgroundService> _logger;
     private readonly IOptions<CdpOptions> _cdpOptions;
     private readonly IWebProxy _webProxy;
+    private readonly AzureMetrics _azureMetrics;
     private readonly ServiceBusClient _client;
     private readonly ServiceBusReceiver _receiver;
 
     public AzureDeadLetterBackgroundService(
         ServiceBusSubscriptionOptions options,
+        string consumerName,
         ILogger<AzureDeadLetterBackgroundService> logger,
         IOptions<CdpOptions> cdpOptions,
-        IWebProxy webProxy
+        IWebProxy webProxy,
+        AzureMetrics azureMetrics
     )
     {
         _options = options;
+        _consumerName = consumerName;
         _logger = logger;
         _cdpOptions = cdpOptions;
         _webProxy = webProxy;
+        _azureMetrics = azureMetrics;
+
         _client = CreateClient();
         _receiver = _client.CreateReceiver(
             _options.Topic,
@@ -41,37 +47,20 @@ public class AzureDeadLetterBackgroundService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await Task.Delay(_startDelay, stoppingToken);
+        // Wait for a random amount of time to minimise clashes as this will
+        // run in all deployed instances of the processor
+        var wait = TimeSpan.FromSeconds(Random.Shared.Next(30, 120));
+        await Task.Delay(wait, stoppingToken);
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                var count = 0;
-                int messagesRead;
-                long? lastSequenceNumber = 0;
-
-                do
-                {
-                    var messages = await _receiver.PeekMessagesAsync(
-                        maxMessages: 100,
-                        fromSequenceNumber: lastSequenceNumber,
-                        cancellationToken: stoppingToken
-                    );
-
-                    messagesRead = messages.Count;
-                    count += messagesRead;
-                } while (messagesRead == 100);
+                var count = await PeekTotalMessageCount(stoppingToken);
 
                 _logger.LogInformation("Dead letter monitor for {Topic}, count {Count}", _options.Topic, count);
 
-                // Would set our metric here with the DLQ count we have found
-
-                // Considerations:
-                // All deployed instances would be executing this code so we should consider a random start/jitter.
-                // The volume of messages on the DLQ would impact the performance of the code above.
-                // There is an "admin" client but it only works over HTTP and we would need specific permissions
-                //   to call it beyond our current SAS token.
+                _azureMetrics.DeadLetter(_consumerName, count);
             }
             catch (Exception exception)
             {
@@ -80,6 +69,26 @@ public class AzureDeadLetterBackgroundService : BackgroundService
 
             await Task.Delay(_delay, stoppingToken);
         }
+    }
+
+    private async Task<int> PeekTotalMessageCount(CancellationToken stoppingToken)
+    {
+        var count = 0;
+        int read;
+        long? from = 0;
+        const int batch = 100;
+
+        do
+        {
+            var messages = await _receiver.PeekMessagesAsync(batch, from, stoppingToken);
+
+            read = messages.Count;
+            count += read;
+
+            await Task.Delay(100, stoppingToken);
+        } while (read == batch);
+
+        return count;
     }
 
     public override async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
+++ b/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Azure.Messaging.ServiceBus;
 using Defra.TradeImportsProcessor.Processor.Configuration;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace Defra.TradeImportsProcessor.Processor.Metrics;
 
+[ExcludeFromCodeCoverage]
 public class AzureDeadLetterBackgroundService : BackgroundService
 {
     private readonly TimeSpan _delay = TimeSpan.FromMinutes(5);

--- a/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
+++ b/src/Processor/Metrics/AzureDeadLetterBackgroundService.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using Azure.Messaging.ServiceBus;
+using Defra.TradeImportsProcessor.Processor.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Defra.TradeImportsProcessor.Processor.Metrics;
+
+public class AzureDeadLetterBackgroundService : BackgroundService
+{
+    private readonly TimeSpan _startDelay = TimeSpan.FromSeconds(60);
+    private readonly TimeSpan _delay = TimeSpan.FromSeconds(30);
+    private readonly ServiceBusSubscriptionOptions _options;
+    private readonly ILogger<AzureDeadLetterBackgroundService> _logger;
+    private readonly IOptions<CdpOptions> _cdpOptions;
+    private readonly IWebProxy _webProxy;
+    private readonly ServiceBusClient _client;
+    private readonly ServiceBusReceiver _receiver;
+
+    public AzureDeadLetterBackgroundService(
+        ServiceBusSubscriptionOptions options,
+        ILogger<AzureDeadLetterBackgroundService> logger,
+        IOptions<CdpOptions> cdpOptions,
+        IWebProxy webProxy
+    )
+    {
+        _options = options;
+        _logger = logger;
+        _cdpOptions = cdpOptions;
+        _webProxy = webProxy;
+        _client = CreateClient();
+        _receiver = _client.CreateReceiver(
+            _options.Topic,
+            _options.Subscription,
+            new ServiceBusReceiverOptions
+            {
+                SubQueue = SubQueue.DeadLetter,
+                ReceiveMode = ServiceBusReceiveMode.PeekLock,
+            }
+        );
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(_startDelay, stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var count = 0;
+                int messagesRead;
+                long? lastSequenceNumber = 0;
+
+                do
+                {
+                    var messages = await _receiver.PeekMessagesAsync(
+                        maxMessages: 100,
+                        fromSequenceNumber: lastSequenceNumber,
+                        cancellationToken: stoppingToken
+                    );
+
+                    messagesRead = messages.Count;
+                    count += messagesRead;
+                } while (messagesRead == 100);
+
+                _logger.LogInformation("Dead letter monitor for {Topic}, count {Count}", _options.Topic, count);
+
+                // Would set our metric here with the DLQ count we have found
+
+                // Considerations:
+                // All deployed instances would be executing this code so we should consider a random start/jitter.
+                // The volume of messages on the DLQ would impact the performance of the code above.
+                // There is an "admin" client but it only works over HTTP and we would need specific permissions
+                //   to call it beyond our current SAS token.
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "Failed to get dead letter count for {Topic}", _options.Topic);
+            }
+
+            await Task.Delay(_delay, stoppingToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _receiver.DisposeAsync();
+        await _client.DisposeAsync();
+
+        await base.StopAsync(cancellationToken);
+    }
+
+    private ServiceBusClient CreateClient()
+    {
+        var clientOptions = !_cdpOptions.Value.IsProxyEnabled
+            ? new ServiceBusClientOptions()
+            : new ServiceBusClientOptions
+            {
+                WebProxy = _webProxy,
+                TransportType = ServiceBusTransportType.AmqpWebSockets,
+            };
+
+        return new ServiceBusClient(_options.ConnectionString, clientOptions);
+    }
+}

--- a/src/Processor/Metrics/AzureMetrics.cs
+++ b/src/Processor/Metrics/AzureMetrics.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using Amazon.CloudWatch.EMF.Model;
+
+namespace Defra.TradeImportsProcessor.Processor.Metrics;
+
+[ExcludeFromCodeCoverage]
+public class AzureMetrics
+{
+    private readonly Gauge<long> _deadLetterTotal;
+
+    public AzureMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
+
+        _deadLetterTotal = meter.CreateGauge<long>(
+            "MessagingAzureDeadLetter",
+            nameof(Unit.COUNT),
+            description: "Number of messages on DLQ"
+        );
+    }
+
+    public void DeadLetter(string model, long count)
+    {
+        _deadLetterTotal.Record(count, BuildTags(model));
+    }
+
+    private static TagList BuildTags(string model)
+    {
+        return new TagList
+        {
+            { Constants.Tags.Service, Process.GetCurrentProcess().ProcessName },
+            { Constants.Tags.Model, model },
+        };
+    }
+
+    private static class Constants
+    {
+        public static class Tags
+        {
+            public const string Model = "ModelType";
+            public const string Service = "ServiceName";
+        }
+    }
+}

--- a/src/Processor/Metrics/ConsumerMetrics.cs
+++ b/src/Processor/Metrics/ConsumerMetrics.cs
@@ -19,6 +19,11 @@ public class ConsumerMetrics : IConsumerMetrics
     {
         var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
 
+        _consumeDuration = meter.CreateHistogram<double>(
+            "MessagingConsumeDuration",
+            nameof(Unit.MILLISECONDS),
+            "Elapsed time spent consuming a message, in millis"
+        );
         _consumeTotal = meter.CreateCounter<long>(
             "MessagingConsume",
             nameof(Unit.COUNT),
@@ -43,11 +48,6 @@ public class ConsumerMetrics : IConsumerMetrics
             "MessagingConsumeActive",
             nameof(Unit.COUNT),
             description: "Number of consumers in progress"
-        );
-        _consumeDuration = meter.CreateHistogram<double>(
-            "MessagingConsumeDuration",
-            nameof(Unit.MILLISECONDS),
-            "Elapsed time spent consuming a message, in millis"
         );
     }
 

--- a/src/Processor/Metrics/ConsumerMetrics.cs
+++ b/src/Processor/Metrics/ConsumerMetrics.cs
@@ -12,7 +12,6 @@ public class ConsumerMetrics : IConsumerMetrics
     private readonly Counter<long> _consumeTotal;
     private readonly Counter<long> _consumeFaultTotal;
     private readonly Counter<long> _consumeWarnTotal;
-    private readonly Counter<long> _consumeDeadLetterTotal;
     private readonly Counter<long> _consumerInProgress;
 
     public ConsumerMetrics(IMeterFactory meterFactory)
@@ -39,11 +38,6 @@ public class ConsumerMetrics : IConsumerMetrics
             nameof(Unit.COUNT),
             description: "Number of message consume warnings"
         );
-        _consumeDeadLetterTotal = meter.CreateCounter<long>(
-            "MessagingConsumeDeadLetters",
-            nameof(Unit.COUNT),
-            description: "Number of message consume dead letters"
-        );
         _consumerInProgress = meter.CreateCounter<long>(
             "MessagingConsumeActive",
             nameof(Unit.COUNT),
@@ -64,6 +58,7 @@ public class ConsumerMetrics : IConsumerMetrics
         var tagList = BuildTags(queueName, consumerName, resourceType);
 
         tagList.Add(Constants.Tags.ExceptionType, exception.GetType().Name);
+
         _consumeFaultTotal.Add(1, tagList);
     }
 
@@ -72,15 +67,8 @@ public class ConsumerMetrics : IConsumerMetrics
         var tagList = BuildTags(queueName, consumerName, resourceType);
 
         tagList.Add(Constants.Tags.ExceptionType, exception.GetType().Name);
+
         _consumeWarnTotal.Add(1, tagList);
-    }
-
-    public void DeadLetter(string queueName, string consumerName, string resourceType, Exception exception)
-    {
-        var tagList = BuildTags(queueName, consumerName, resourceType);
-
-        tagList.Add(Constants.Tags.ExceptionType, exception.GetType().Name);
-        _consumeDeadLetterTotal.Add(1, tagList);
     }
 
     public void Complete(string queueName, string consumerName, double milliseconds, string resourceType)

--- a/src/Processor/Metrics/IConsumerMetrics.cs
+++ b/src/Processor/Metrics/IConsumerMetrics.cs
@@ -5,6 +5,5 @@ public interface IConsumerMetrics
     void Start(string path, string consumerName, string resourceType);
     void Faulted(string queueName, string consumerName, string resourceType, Exception exception);
     void Warn(string queueName, string consumerName, string resourceType, Exception exception);
-    void DeadLetter(string queueName, string consumerName, string resourceType, Exception exception);
     void Complete(string queueName, string consumerName, double milliseconds, string resourceType);
 }

--- a/src/Processor/Metrics/RequestMetrics.cs
+++ b/src/Processor/Metrics/RequestMetrics.cs
@@ -19,14 +19,12 @@ public class RequestMetrics
             nameof(Unit.COUNT),
             "Count of messages received"
         );
-
+        _requestsFaulted = meter.CreateCounter<long>("RequestFaulted", nameof(Unit.COUNT), "Count of request faults");
         _requestDuration = meter.CreateHistogram<double>(
             "RequestDuration",
             nameof(Unit.MILLISECONDS),
             "Duration of request"
         );
-
-        _requestsFaulted = meter.CreateCounter<long>("RequestFaulted", nameof(Unit.COUNT), "Count of request faults");
     }
 
     public void RequestCompleted(string requestPath, string httpMethod, int statusCode, double milliseconds)

--- a/src/Processor/Program.cs
+++ b/src/Processor/Program.cs
@@ -4,6 +4,8 @@ using Defra.TradeImportsProcessor.Processor.Endpoints;
 using Defra.TradeImportsProcessor.Processor.Extensions;
 using Defra.TradeImportsProcessor.Processor.Health;
 using Defra.TradeImportsProcessor.Processor.Metrics;
+using Defra.TradeImportsProcessor.Processor.Models.Gmrs;
+using Defra.TradeImportsProcessor.Processor.Models.ImportNotification;
 using Defra.TradeImportsProcessor.Processor.Utils;
 using Defra.TradeImportsProcessor.Processor.Utils.Http;
 using Defra.TradeImportsProcessor.Processor.Utils.Logging;
@@ -67,12 +69,17 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
 
     builder.Services.AddTransient<MetricsMiddleware>();
     builder.Services.AddSingleton<RequestMetrics>();
+    builder.Services.AddSingleton<AzureMetrics>();
     builder.Services.Add(
         ServiceDescriptor.Singleton<IHostedService>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
 
-            return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(sp, options.Notifications);
+            return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(
+                sp,
+                options.Notifications,
+                nameof(ImportNotification)
+            );
         })
     );
     builder.Services.Add(
@@ -80,7 +87,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
         {
             var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
 
-            return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(sp, options.Gmrs);
+            return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(sp, options.Gmrs, nameof(Gmr));
         })
     );
 }

--- a/src/Processor/Utils/Http/Proxy.cs
+++ b/src/Processor/Utils/Http/Proxy.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.Http.Headers;
 using Defra.TradeImportsProcessor.Processor.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -32,6 +31,7 @@ public static class Proxy
     {
         var options = sp.GetRequiredService<IOptions<CdpOptions>>();
         var proxy = sp.GetRequiredService<IWebProxy>();
+
         return CreateHttpClientHandler(proxy, options.Value.CdpHttpsProxy!);
     }
 
@@ -58,12 +58,14 @@ public static class Proxy
     public static void ConfigureProxy(WebProxy proxy, string proxyUri, ILogger logger)
     {
         logger.LogDebug("Creating proxy http client");
+
         var uri = new UriBuilder(proxyUri);
 
         var credentials = GetCredentialsFromUri(uri);
         if (credentials != null)
         {
             logger.LogDebug("Setting proxy credentials");
+
             proxy.Credentials = credentials;
         }
 
@@ -77,8 +79,10 @@ public static class Proxy
     {
         var username = uri.UserName;
         var password = uri.Password;
+
         if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
             return null;
+
         return new NetworkCredential(username, password);
     }
 }


### PR DESCRIPTION
Potentially controversial - this proposal allows the dead letter queue count from Azure for the two topics we consumer (notifications and GMRs) to be peeked, which are then written as a metric in AWS.

We were doing these previously when consumption from Azure resulted in a dead letter scenario. But we were incrementing a metric so if the DLQ was emptied, our metric would still be incrementing.

With this change, the metric we visualise and alert on will be tracking the actual number of messages on the DLQ at a point in time.

Obviously, this polling logic will run in however many hosts of the processor are deployed. There is a startup delay for each host that will ensure the polling starts between 30 and 120 seconds from host instantiation. The wait period between poll cycles is 5 minutes.

We cannot use the recommended approach for returning queue stats as we only have a SAS key and not a service account with appropriate service bus privileges. Therefore, we use the service bus to peek messages from the DLQ.

If the DLQ is large, this could result in a lot of calls via the service bus client as we're batching by 100 messages at a time. The fact the DLQ is large is a problem in itself and we could argue that anything on the DLQ should be a rare occurrence. However, it is a risk nonetheless.

What is in this PR is good enough for now and we can monitor it over time.