### PR TITLE
Temp removal of background service to peek DLQ messages

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -77,31 +77,6 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<RequestMetrics>();
         services.AddSingleton<AzureMetrics>();
 
-        services.Add(
-            ServiceDescriptor.Singleton<IHostedService>(sp =>
-            {
-                var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
-
-                return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(
-                    sp,
-                    options.Notifications,
-                    nameof(ImportNotification)
-                );
-            })
-        );
-        services.Add(
-            ServiceDescriptor.Singleton<IHostedService>(sp =>
-            {
-                var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
-
-                return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(
-                    sp,
-                    options.Gmrs,
-                    nameof(Gmr)
-                );
-            })
-        );
-
         return services;
     }
 


### PR DESCRIPTION
Something is removing messages from the DLQ or they are expiring quicker than expected.

Removing the new DLQ peeking to rule this out as a cause.