### PR TITLE
Revert "Temp removal of background service to peek DLQ messages"

### DIFF
--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -77,6 +77,31 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<RequestMetrics>();
         services.AddSingleton<AzureMetrics>();
 
+        services.Add(
+            ServiceDescriptor.Singleton<IHostedService>(sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
+
+                return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(
+                    sp,
+                    options.Notifications,
+                    nameof(ImportNotification)
+                );
+            })
+        );
+        services.Add(
+            ServiceDescriptor.Singleton<IHostedService>(sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value;
+
+                return ActivatorUtilities.CreateInstance<AzureDeadLetterBackgroundService>(
+                    sp,
+                    options.Gmrs,
+                    nameof(Gmr)
+                );
+            })
+        );
+
         return services;
     }
 


### PR DESCRIPTION
Reverts DEFRA/trade-imports-processor#171

DLQ is being emptied by something else, therefore restoring this work.