### PR TITLE
CDMS-653: turn on IPAFFS message consumption (prod)

### DIFF
--- a/src/Processor/appsettings.cdp.prod.json
+++ b/src/Processor/appsettings.cdp.prod.json
@@ -12,7 +12,7 @@
       "Subscription": "defra.trade.dmp.btms-ingest.prd.1001.subscription"
     },
     "Notifications": {
-      "AutoStartConsumers": false,
+      "AutoStartConsumers": true,
       "Topic": "notification-topic",
       "Subscription": "btms"
     }


### PR DESCRIPTION
To consume messages from the IPAFFS notification topic subscription