### PR TITLE
Turn on GMR consumption in prod

### DIFF
--- a/src/Processor/appsettings.cdp.prod.json
+++ b/src/Processor/appsettings.cdp.prod.json
@@ -7,13 +7,11 @@
   },
   "ServiceBus": {
     "Gmrs": {
-      "AutoStartConsumers": false,
       "ConsumersPerHost": 2,
       "Topic": "defra.trade.dmp.outputgmrs.prd.1001.topic",
       "Subscription": "defra.trade.dmp.btms-ingest.prd.1001.subscription"
     },
     "Notifications": {
-      "AutoStartConsumers": true,
       "Topic": "notification-topic",
       "Subscription": "btms"
     }


### PR DESCRIPTION
As per PR title.

The main appsettings.json sets `AutoStartConsumers` to `true`, therefore config can be removed in the prod appsettings.json so we accept the default value.