### PR TITLE
Allow GMR to be updated if it already exists

### DIFF
--- a/tests/TestFixtures/GmrFixtures.cs
+++ b/tests/TestFixtures/GmrFixtures.cs
@@ -13,6 +13,6 @@ public static class GmrFixtures
 
     public static IPostprocessComposer<Gmr> GmrFixture()
     {
-        return GetFixture().Build<Gmr>();
+        return GetFixture().Build<Gmr>().With(x => x.UpdatedDateTime, DateTime.UtcNow);
     }
 }


### PR DESCRIPTION
We see write errors when a GMR already exists, therefore we are processing updates as well as inserts.

This PR updates the consumer so it can determine if it needs to save the GMR. It uses the `UpdatedDateTime` of the GMR to determine if what is stored is the latest update for us to store.

This logic is equivalent to what happens for IPAFFS.