### PR TITLE
Add log alongside metric write for warning and fault so we triage and find affected resources more easily

### DIFF
--- a/src/Processor/Extensions/ConsumerContextExtensions.cs
+++ b/src/Processor/Extensions/ConsumerContextExtensions.cs
@@ -15,6 +15,7 @@ public static class MessageBusHeaders
     public const string SqsBusMessage = "Sqs_Message";
     public const string ServiceBusMessage = "ServiceBus_Message";
     public const string ResourceId = "ResourceId";
+    public const string TraceId = "x-cdp-request-id";
 }
 
 [ExcludeFromCodeCoverage]

--- a/src/Processor/Metrics/MetricsInterceptor.cs
+++ b/src/Processor/Metrics/MetricsInterceptor.cs
@@ -7,14 +7,23 @@ using SlimMessageBus.Host.Interceptor;
 namespace Defra.TradeImportsProcessor.Processor.Metrics;
 
 [ExcludeFromCodeCoverage]
-public class MetricsInterceptor<TMessage>(IConsumerMetrics consumerMetrics) : IConsumerInterceptor<TMessage>
+public class MetricsInterceptor<TMessage>(
+    IConsumerMetrics consumerMetrics,
+    ILogger<MetricsInterceptor<TMessage>> logger
+) : IConsumerInterceptor<TMessage>
     where TMessage : notnull
 {
+    [SuppressMessage(
+        "Minor Code Smell",
+        "S6667:Logging in a catch clause should pass the caught exception as a parameter. "
+            + "- the exception is thrown, we do not want to log here as the logging interceptor will do that"
+    )]
     public async Task<object> OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context)
     {
         var startingTimestamp = TimeProvider.System.GetTimestamp();
         var consumerName = context.Consumer.GetType().Name;
         var resourceType = context.GetResourceType();
+        var resourceId = context.GetResourceId();
 
         try
         {
@@ -27,11 +36,15 @@ public class MetricsInterceptor<TMessage>(IConsumerMetrics consumerMetrics) : IC
         {
             consumerMetrics.Warn(context.Path, consumerName, resourceType, httpRequestException);
 
+            LogForTriaging("Warn", consumerName, resourceId, resourceType);
+
             throw;
         }
         catch (Exception exception)
         {
             consumerMetrics.Faulted(context.Path, consumerName, resourceType, exception);
+
+            LogForTriaging("Faulted", consumerName, resourceId, resourceType);
 
             throw;
         }
@@ -44,5 +57,24 @@ public class MetricsInterceptor<TMessage>(IConsumerMetrics consumerMetrics) : IC
                 resourceType
             );
         }
+    }
+
+    /// <summary>
+    /// Intentionally an information log as this supports triaging, not alerting.
+    /// The logging interceptor will log for the benefit of alerting.
+    /// </summary>
+    /// <param name="level"></param>
+    /// <param name="consumerName"></param>
+    /// <param name="resourceId"></param>
+    /// <param name="resourceType"></param>
+    private void LogForTriaging(string level, string consumerName, string resourceId, string resourceType)
+    {
+        logger.LogInformation(
+            "{Level} consumer {Consumer} for resource {Resource} of type {Type}",
+            level,
+            consumerName,
+            resourceId,
+            resourceType
+        );
     }
 }


### PR DESCRIPTION
As per PR title.

Running the integration tests will show console logs in the processor for deserialisation/consumption errors.

This does not need to deployed in order to show it's working.