### PR TITLE
Store incoming message being consumed in local env and in CDP DEV

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,11 +43,14 @@ services:
         condition: service_healthy
       wiremock:
         condition: service_started
+      mongodb:
+        condition: service_healthy
     env_file:
       - 'compose/aws.env'
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ENVIRONMENT: local
+      SERVICE_VERSION: local
       PORT: 8080
       DataApi__BaseAddress: "http://wiremock"
       DataApi__Password: "secret"
@@ -55,6 +58,9 @@ services:
       ServiceBus__Notifications__ConnectionString: "Endpoint=sb://asb-backend;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
       SQS_ENDPOINT: http://localstack:4566
       AWS_EMF_ENVIRONMENT: Local
+      Mongo__DatabaseUri: mongodb://mongodb:27017/?directConnection=true
+      RawMessageLogging__Enabled: true
+      Acl__Clients__IntegrationTests__Secret: integration-tests-pwd
     image: trade-imports-processor:latest
     ports:
       - "8080:8080"
@@ -108,3 +114,33 @@ services:
       interval: 5s
       start_period: 5s
       retries: 10
+      
+  mongodb:
+    # Initialise a Mongo cluster with a replicaset of 1 node.
+    # Based on https://medium.com/workleap/the-only-local-mongodb-replica-set-with-docker-compose-guide-youll-ever-need-2f0b74dd8384
+    # Since we are using transactions, we require a replicaset. Local dev with docker compose uses 1 node below, but our live
+    # environments have multiple nodes.
+    # The replicaset needs initialising, so the healthcheck can be hijacked to initialise this so that it can keep retrying
+    # until the operation is successful (might need to wait a while after container boot for this to work, hence the interval/retries)
+    # WARNING: do not turn on authentication, otherwise will need to deal with generating key pairs and sharing them between
+    # the replicaset nodes. For local development this is overkill, so just turn off auth and connect to Mongo without creds.
+    container_name: processor-mongodb
+    image: mongo:6.0.13
+    command: [ "--replSet", "rs0", "--bind_ip_all", "--port", "27017" ]
+    ports:
+      - "27017:27017"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
+    volumes:
+      - mongodb-data:/data
+    restart: always
+
+volumes:
+  mongodb-data:

--- a/src/Processor/Configuration/RawMessageLoggingOptions.cs
+++ b/src/Processor/Configuration/RawMessageLoggingOptions.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Defra.TradeImportsProcessor.Processor.Configuration;
+
+public class RawMessageLoggingOptions
+{
+    public const string SectionName = "RawMessageLogging";
+
+    public bool Enabled { get; init; } = false;
+
+    [Range(1, 30)]
+    public int TtlDays { get; init; } = 7;
+}

--- a/src/Processor/Consumers/RawMessageLoggingInterceptor.cs
+++ b/src/Processor/Consumers/RawMessageLoggingInterceptor.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Defra.TradeImportsProcessor.Processor.Configuration;
+using Defra.TradeImportsProcessor.Processor.Data;
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+using Defra.TradeImportsProcessor.Processor.Extensions;
+using Defra.TradeImportsProcessor.Processor.Models.ImportNotification;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using SlimMessageBus;
+using SlimMessageBus.Host.Interceptor;
+using Gmr = Defra.TradeImportsProcessor.Processor.Models.Gmrs.Gmr;
+
+namespace Defra.TradeImportsProcessor.Processor.Consumers;
+
+[ExcludeFromCodeCoverage]
+public class RawMessageLoggingInterceptor<TMessage>(
+    IDbContext dbContext,
+    ILogger<RawMessageLoggingInterceptor<TMessage>> logger,
+    IOptions<RawMessageLoggingOptions> options
+) : IConsumerInterceptor<TMessage>
+{
+    public async Task<object> OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context)
+    {
+        try
+        {
+            if (message is not JsonElement jsonElement)
+                return await next();
+
+            var resourceType = context.GetResourceType();
+            if (resourceType == ResourceTypes.Unknown)
+                return await next();
+
+            var entity = new RawMessageEntity
+            {
+                Id = ObjectId.GenerateNewId().ToString(),
+                ResourceId = GetResourceId(resourceType, jsonElement, context),
+                ResourceType = resourceType,
+                MessageId = context.GetMessageId(),
+                Headers = context.Headers.ToDictionary(x => x.Key, x => x.Value),
+                Message = jsonElement.GetRawText(),
+                ExpiresAt = DateTime.UtcNow.AddDays(options.Value.TtlDays),
+            };
+
+            await dbContext.StartTransaction(context.CancellationToken);
+            dbContext.RawMessages.Insert(entity);
+            await dbContext.SaveChanges(context.CancellationToken);
+            await dbContext.CommitTransaction(context.CancellationToken);
+
+            return await next();
+        }
+#pragma warning disable S2139
+        catch (Exception exception)
+#pragma warning restore S2139
+        {
+            logger.LogWarning(exception, "Failed to log raw message");
+
+            throw;
+        }
+    }
+
+    private static string GetResourceId(string resourceType, JsonElement jsonElement, IConsumerContext context)
+    {
+        var result = resourceType switch
+        {
+            ResourceTypes.Gmr => jsonElement.GetProperty(nameof(Gmr.GmrId)).GetString(),
+            ResourceTypes.ImportPreNotification => jsonElement
+                .GetProperty(
+                    // Currently case-sensitive based on JsonPropertyName on type
+                    char.ToLower(nameof(ImportNotification.ReferenceNumber)[0])
+                        + nameof(ImportNotification.ReferenceNumber)[1..]
+                )
+                .GetString(),
+            _ => context.GetResourceId(),
+        };
+
+        return result ?? "Unknown";
+    }
+}

--- a/src/Processor/Data/ConcurrencyException.cs
+++ b/src/Processor/Data/ConcurrencyException.cs
@@ -1,0 +1,18 @@
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public class ConcurrencyException : Exception
+{
+    public ConcurrencyException(string entityId, string entityEtag)
+        : base($"Failed up update {entityId} with etag {entityEtag}")
+    {
+        EntityId = entityId;
+        EntityEtag = entityEtag;
+    }
+
+    public ConcurrencyException(string message, Exception inner)
+        : base(message, inner) { }
+
+    public string? EntityId { get; }
+
+    public string? EntityEtag { get; }
+}

--- a/src/Processor/Data/Entities/DataEntityExtensions.cs
+++ b/src/Processor/Data/Entities/DataEntityExtensions.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsProcessor.Processor.Data.Entities;
+
+public static class DataEntityExtensions
+{
+    public static string DataEntityName(this Type type) => type.Name.Replace("Entity", "");
+}

--- a/src/Processor/Data/Entities/IDataEntity.cs
+++ b/src/Processor/Data/Entities/IDataEntity.cs
@@ -1,0 +1,15 @@
+namespace Defra.TradeImportsProcessor.Processor.Data.Entities;
+
+public interface IDataEntity
+{
+    public string Id { get; set; }
+
+    // ReSharper disable once InconsistentNaming - want to use Mongo DB convention to indicate none core schema properties
+    public string ETag { get; set; }
+
+    public DateTime Created { get; set; }
+
+    public DateTime Updated { get; set; }
+
+    void OnSave();
+}

--- a/src/Processor/Data/Entities/RawMessageEntity.cs
+++ b/src/Processor/Data/Entities/RawMessageEntity.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Entities;
+
+public class RawMessageEntity : IDataEntity
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("etag")]
+    public string ETag { get; set; } = null!;
+
+    [JsonPropertyName("created")]
+    public DateTime Created { get; set; }
+
+    [JsonPropertyName("updated")]
+    public DateTime Updated { get; set; }
+
+    [JsonPropertyName("resourceId")]
+    public required string ResourceId { get; set; }
+
+    [JsonPropertyName("resourceType")]
+    public required string ResourceType { get; set; }
+
+    [JsonPropertyName("headers")]
+    public Dictionary<string, object> Headers { get; set; } = [];
+
+    [JsonPropertyName("messageId")]
+    public required string MessageId { get; set; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; set; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTime? ExpiresAt { get; set; }
+
+    public void OnSave() { }
+}

--- a/src/Processor/Data/Extensions/QueryableExtensions.cs
+++ b/src/Processor/Data/Extensions/QueryableExtensions.cs
@@ -1,0 +1,32 @@
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Extensions;
+
+public static class QueryableExtensions
+{
+    public static async Task<List<TSource>> ToListWithFallbackAsync<TSource>(
+        this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (source is IAsyncCursorSource<TSource> cursorSource)
+        {
+            return await cursorSource.ToListAsync(cancellationToken);
+        }
+
+        return source.AsEnumerable().ToList();
+    }
+
+    public static async Task<TSource?> FirstOrDefaultWithFallbackAsync<TSource>(
+        this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (source is IAsyncCursorSource<TSource> cursorSource)
+        {
+            return await cursorSource.FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return source.AsEnumerable().FirstOrDefault();
+    }
+}

--- a/src/Processor/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using Defra.TradeImportsProcessor.Processor.Data.Mongo;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+using MongoDB.Driver;
+using MongoDB.Driver.Authentication.AWS;
+using MongoDB.Driver.Core.Events;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddDbContext(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        bool integrationTest
+    )
+    {
+        services
+            .AddOptions<MongoDbOptions>()
+            .Bind(configuration.GetSection(MongoDbOptions.SectionName))
+            .ValidateDataAnnotations();
+
+        if (integrationTest)
+            return services;
+
+        services.AddHostedService<MongoIndexService>();
+        services.AddScoped<IDbContext, MongoDbContext>();
+        services.AddSingleton<MongoCommandTracker>();
+        services.AddSingleton(sp =>
+        {
+            MongoClientSettings.Extensions.AddAWSAuthentication();
+
+            var options =
+                sp.GetService<IOptions<MongoDbOptions>>() ?? throw new InvalidOperationException("Options not found");
+            var settings = MongoClientSettings.FromConnectionString(options.Value.DatabaseUri);
+
+            if (options.Value.QueryLogging)
+            {
+                var commandTracker = sp.GetRequiredService<MongoCommandTracker>();
+
+                settings.ClusterConfigurator = cb =>
+                {
+                    cb.Subscribe<CommandStartedEvent>(commandTracker.OnCommandStarted);
+                    cb.Subscribe<CommandSucceededEvent>(commandTracker.OnCommandSucceeded);
+                    cb.Subscribe<CommandFailedEvent>(commandTracker.OnCommandFailed);
+                };
+            }
+
+            var client = new MongoClient(settings);
+            var conventionPack = new ConventionPack
+            {
+                new CamelCaseElementNameConvention(),
+                new EnumRepresentationConvention(BsonType.String),
+            };
+
+            ConventionRegistry.Register(nameof(conventionPack), conventionPack, _ => true);
+
+            return client.GetDatabase(options.Value.DatabaseName);
+        });
+
+        return services;
+    }
+
+    private sealed class MongoCommandTracker(ILogger<MongoCommandTracker> logger)
+    {
+        private readonly ConcurrentDictionary<long, Command> _commands = new();
+
+        private sealed record Command(string CommandName, string Query, long Timestamp);
+
+        public void OnCommandStarted(CommandStartedEvent @event)
+        {
+            if (@event.OperationId is not null && ShouldTrack(@event))
+                _commands.TryAdd(
+                    @event.OperationId.Value,
+                    new Command(@event.CommandName, @event.Command.ToJson(), TimeProvider.System.GetTimestamp())
+                );
+        }
+
+        public void OnCommandSucceeded(CommandSucceededEvent @event)
+        {
+            if (@event.OperationId is not null && _commands.TryRemove(@event.OperationId.Value, out var commandInfo))
+                Log(LogLevel.Information, commandInfo);
+        }
+
+        public void OnCommandFailed(CommandFailedEvent @event)
+        {
+            if (@event.OperationId is not null && _commands.TryRemove(@event.OperationId.Value, out var commandInfo))
+                Log(LogLevel.Warning, commandInfo);
+        }
+
+        private void Log(LogLevel level, Command command) =>
+            logger.Log(
+                level,
+                "Mongo query {Result} {CommandName} {Query} took {Duration}ms",
+                level == LogLevel.Information ? "succeeded" : "failed",
+                command.CommandName,
+                command.Query,
+                TimeProvider.System.GetElapsedTime(command.Timestamp).TotalMilliseconds
+            );
+
+        private static bool ShouldTrack(CommandStartedEvent @event) =>
+            @event.CommandName is "find" or "aggregate" or "count" or "distinct";
+    }
+}

--- a/src/Processor/Data/IDbContext.cs
+++ b/src/Processor/Data/IDbContext.cs
@@ -1,0 +1,14 @@
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public interface IDbContext
+{
+    IMongoCollectionSet<RawMessageEntity> RawMessages { get; }
+
+    Task SaveChanges(CancellationToken cancellationToken);
+
+    Task StartTransaction(CancellationToken cancellationToken);
+
+    Task CommitTransaction(CancellationToken cancellationToken);
+}

--- a/src/Processor/Data/IDbTransaction.cs
+++ b/src/Processor/Data/IDbTransaction.cs
@@ -1,0 +1,6 @@
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public interface IDbTransaction : IDisposable
+{
+    Task Commit(CancellationToken cancellationToken);
+}

--- a/src/Processor/Data/IFieldUpdateBuilder.cs
+++ b/src/Processor/Data/IFieldUpdateBuilder.cs
@@ -1,0 +1,8 @@
+using System.Linq.Expressions;
+
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public interface IFieldUpdateBuilder<T>
+{
+    IFieldUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value);
+}

--- a/src/Processor/Data/IMongoCollectionSet.cs
+++ b/src/Processor/Data/IMongoCollectionSet.cs
@@ -1,0 +1,23 @@
+using System.Linq.Expressions;
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public interface IMongoCollectionSet<T> : IQueryable<T>
+    where T : IDataEntity
+{
+    IMongoCollection<T> Collection { get; }
+
+    Task<T?> Find(string id, CancellationToken cancellationToken);
+
+    Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken);
+
+    void Insert(T item);
+
+    void Update(T item, string etag);
+
+    void Update(T item, Action<IFieldUpdateBuilder<T>> patch, string etag);
+
+    Task Save(CancellationToken cancellationToken);
+}

--- a/src/Processor/Data/Mongo/MongoCollectionSet.cs
+++ b/src/Processor/Data/Mongo/MongoCollectionSet.cs
@@ -1,0 +1,174 @@
+using System.Collections;
+using System.Linq.Expressions;
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Mongo;
+
+public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionName = null!) : IMongoCollectionSet<T>
+    where T : class, IDataEntity
+{
+    private readonly List<T> _entitiesToInsert = [];
+    private readonly List<(T Item, string Etag)> _entitiesToUpdate = [];
+    private readonly List<(string Id, UpdateDefinition<T> Patch, string Etag)> _entitiesToPatch = [];
+
+    private IQueryable<T> EntityQueryable => Collection.AsQueryable();
+
+    public IEnumerator<T> GetEnumerator() => EntityQueryable.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => EntityQueryable.GetEnumerator();
+
+    public Type ElementType => EntityQueryable.ElementType;
+    public Expression Expression => EntityQueryable.Expression;
+    public IQueryProvider Provider => EntityQueryable.Provider;
+
+    public IMongoCollection<T> Collection { get; } =
+        string.IsNullOrEmpty(collectionName)
+            ? dbContext.Database.GetCollection<T>(typeof(T).DataEntityName())
+            : dbContext.Database.GetCollection<T>(collectionName);
+
+    public async Task<T?> Find(string id, CancellationToken cancellationToken) =>
+        await EntityQueryable.SingleOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
+
+    public async Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken) =>
+        await EntityQueryable.Where(query).ToListAsync(cancellationToken);
+
+    public async Task Save(CancellationToken cancellationToken)
+    {
+        await Insert(cancellationToken);
+        await Update(cancellationToken);
+    }
+
+    private async Task Update(CancellationToken cancellationToken)
+    {
+        var builder = Builders<T>.Filter;
+
+        if (_entitiesToUpdate.Count != 0)
+        {
+            var session = GetSession();
+
+            foreach (var item in _entitiesToUpdate)
+            {
+                var filter = builder.Eq(x => x.Id, item.Item.Id) & builder.Eq(x => x.ETag, item.Etag);
+
+                var updateResult = await Collection.ReplaceOneAsync(
+                    session,
+                    filter,
+                    item.Item,
+                    cancellationToken: cancellationToken
+                );
+
+                if (updateResult.ModifiedCount == 0)
+                    throw new ConcurrencyException(item.Item.Id, item.Etag);
+            }
+
+            _entitiesToUpdate.Clear();
+        }
+
+        if (_entitiesToPatch.Count != 0)
+        {
+            var session = GetSession();
+
+            foreach (var item in _entitiesToPatch)
+            {
+                var filter = builder.Eq(x => x.Id, item.Id) & builder.Eq(x => x.ETag, item.Etag);
+
+                var updateResult = await Collection.UpdateOneAsync(
+                    session,
+                    filter,
+                    item.Patch,
+                    cancellationToken: cancellationToken
+                );
+
+                if (updateResult.ModifiedCount == 0)
+                    throw new ConcurrencyException(item.Id, item.Etag);
+            }
+
+            _entitiesToPatch.Clear();
+        }
+    }
+
+    private async Task Insert(CancellationToken cancellationToken)
+    {
+        if (_entitiesToInsert.Count != 0)
+        {
+            var session = GetSession();
+
+            foreach (var item in _entitiesToInsert)
+            {
+                await Collection.InsertOneAsync(session, item, cancellationToken: cancellationToken);
+            }
+
+            _entitiesToInsert.Clear();
+        }
+    }
+
+    private IClientSessionHandle? GetSession()
+    {
+        if (dbContext.ActiveTransaction is null)
+            throw new InvalidOperationException("Transaction has not been started");
+
+        return dbContext.ActiveTransaction.Session;
+    }
+
+    public void Insert(T item)
+    {
+        // Update in memory item now but will only be saved if Save is called
+        item.Created = item.Updated = DateTime.UtcNow;
+        item.ETag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
+        item.OnSave();
+
+        _entitiesToInsert.Add(item);
+    }
+
+    public void Update(T item, string etag)
+    {
+        if (_entitiesToInsert.Exists(x => x.Id == item.Id))
+            return;
+
+        ArgumentNullException.ThrowIfNull(etag);
+
+        _entitiesToUpdate.RemoveAll(x => x.Item.Id == item.Id);
+
+        // Update in memory item now but will only be saved if Save is called
+        item.Updated = DateTime.UtcNow;
+        item.ETag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
+        item.OnSave();
+
+        _entitiesToUpdate.Add(new ValueTuple<T, string>(item, etag));
+    }
+
+    public void Update(T item, Action<IFieldUpdateBuilder<T>> patch, string etag)
+    {
+        if (_entitiesToInsert.Exists(x => x.Id == item.Id))
+            throw new InvalidOperationException("Cannot patch an entity due for insert");
+
+        if (_entitiesToUpdate.Exists(x => x.Item.Id == item.Id))
+            throw new InvalidOperationException("Cannot patch an entity due for update");
+
+        ArgumentNullException.ThrowIfNull(etag);
+
+        _entitiesToPatch.RemoveAll(x => x.Id == item.Id);
+
+        var fieldUpdateBuilder = new MongoFieldUpdateBuilder<T>();
+        patch(fieldUpdateBuilder);
+
+        // Update in memory item now but will only be saved if Save is called
+        item.Updated = DateTime.UtcNow;
+        item.ETag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
+
+        _entitiesToPatch.Add(
+            new ValueTuple<string, UpdateDefinition<T>, string>(
+                item.Id,
+                Builders<T>
+                    .Update.Combine(fieldUpdateBuilder.Build())
+                    // Update fields based on in memory item values
+                    .Set(x => x.Updated, item.Updated)
+                    .Set(x => x.ETag, item.ETag),
+                etag
+            )
+        );
+    }
+}

--- a/src/Processor/Data/Mongo/MongoDbContext.cs
+++ b/src/Processor/Data/Mongo/MongoDbContext.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Mongo;
+
+[ExcludeFromCodeCoverage]
+public class MongoDbContext : IDbContext
+{
+    private readonly ILogger<MongoDbContext> _logger;
+
+    public MongoDbContext(IMongoDatabase database, ILogger<MongoDbContext> logger)
+    {
+        _logger = logger;
+
+        Database = database;
+        RawMessages = new MongoCollectionSet<RawMessageEntity>(this);
+    }
+
+    internal IMongoDatabase Database { get; }
+    internal MongoDbTransaction? ActiveTransaction { get; private set; }
+
+    public IMongoCollectionSet<RawMessageEntity> RawMessages { get; }
+
+    public async Task StartTransaction(CancellationToken cancellationToken)
+    {
+        var session = await Database.Client.StartSessionAsync(cancellationToken: cancellationToken);
+        session.StartTransaction();
+
+        ActiveTransaction = new MongoDbTransaction(session);
+    }
+
+    public async Task CommitTransaction(CancellationToken cancellationToken)
+    {
+        if (ActiveTransaction is null)
+            throw new InvalidOperationException("No active transaction");
+
+        await ActiveTransaction.Commit(cancellationToken);
+
+        ActiveTransaction = null;
+    }
+
+    public async Task SaveChanges(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RawMessages.Save(cancellationToken);
+        }
+        catch (MongoCommandException mongoCommandException) when (mongoCommandException.Code == 112)
+        {
+            const string message = "Mongo write conflict - consumer will retry";
+            _logger.LogWarning(mongoCommandException, message);
+
+            // WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction
+            // - retries are built into consumers of the data API
+            throw new ConcurrencyException(message, mongoCommandException);
+        }
+        catch (MongoWriteException mongoWriteException) when (mongoWriteException.WriteError.Code == 11000)
+        {
+            const string message = "Mongo write error - consumer will retry";
+            _logger.LogWarning(mongoWriteException, message);
+
+            // A write operation resulted in an error. WriteError: { Category : "DuplicateKey", Code : 11000 }
+            // - retries are built into consumers of the data API
+            throw new ConcurrencyException(message, mongoWriteException);
+        }
+    }
+}

--- a/src/Processor/Data/Mongo/MongoDbTransaction.cs
+++ b/src/Processor/Data/Mongo/MongoDbTransaction.cs
@@ -1,0 +1,31 @@
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Mongo;
+
+public class MongoDbTransaction(IClientSessionHandle session) : IDbTransaction
+{
+    public IClientSessionHandle? Session { get; private set; } = session;
+
+    public async Task Commit(CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(Session);
+
+        await Session.CommitTransactionAsync(cancellationToken: cancellationToken);
+
+        Session = null!;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing && Session != null)
+        {
+            Session.Dispose();
+        }
+    }
+}

--- a/src/Processor/Data/Mongo/MongoFieldUpdateBuilder.cs
+++ b/src/Processor/Data/Mongo/MongoFieldUpdateBuilder.cs
@@ -1,0 +1,18 @@
+using System.Linq.Expressions;
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Mongo;
+
+public class MongoFieldUpdateBuilder<T> : IFieldUpdateBuilder<T>
+{
+    private readonly List<UpdateDefinition<T>> _updates = [];
+
+    public IFieldUpdateBuilder<T> Set<TField>(Expression<Func<T, TField>> field, TField value)
+    {
+        _updates.Add(Builders<T>.Update.Set(field, value));
+
+        return this;
+    }
+
+    public UpdateDefinition<T> Build() => Builders<T>.Update.Combine(_updates);
+}

--- a/src/Processor/Data/Mongo/MongoIndexService.cs
+++ b/src/Processor/Data/Mongo/MongoIndexService.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.CodeAnalysis;
+using Defra.TradeImportsProcessor.Processor.Data.Entities;
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsProcessor.Processor.Data.Mongo;
+
+[ExcludeFromCodeCoverage]
+public class MongoIndexService(IMongoDatabase database, ILogger<MongoIndexService> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await CreateIndex(
+            "UpdatedIdx",
+            Builders<RawMessageEntity>.IndexKeys.Ascending(x => x.Updated),
+            cancellationToken: cancellationToken
+        );
+
+        await CreateIndex(
+            "UpdatesIdx",
+            Builders<RawMessageEntity>
+                .IndexKeys.Ascending(x => x.Updated)
+                .Ascending(x => x.ResourceId)
+                .Ascending(x => x.ResourceType)
+                .Ascending(x => x.MessageId),
+            cancellationToken: cancellationToken
+        );
+
+        await CreateTtlIndex(
+            "ExpiresAtTtlIdx",
+            Builders<RawMessageEntity>.IndexKeys.Ascending(x => x.ExpiresAt),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    private async Task CreateIndex<T>(
+        string name,
+        IndexKeysDefinition<T> keys,
+        bool unique = false,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var indexModel = new CreateIndexModel<T>(
+                keys,
+                new CreateIndexOptions
+                {
+                    Name = name,
+                    Background = true,
+                    Unique = unique,
+                }
+            );
+            await database
+                .GetCollection<T>(typeof(T).DataEntityName())
+                .Indexes.CreateOneAsync(indexModel, cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to Create index {Name} on {Collection}", name, typeof(T).DataEntityName());
+        }
+    }
+
+    private async Task CreateTtlIndex<T>(
+        string name,
+        IndexKeysDefinition<T> keys,
+        TimeSpan? expireAfter = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        try
+        {
+            var indexModel = new CreateIndexModel<T>(
+                keys,
+                new CreateIndexOptions
+                {
+                    Name = name,
+                    Background = true,
+                    ExpireAfter = expireAfter ?? TimeSpan.Zero,
+                }
+            );
+            await database
+                .GetCollection<T>(typeof(T).DataEntityName())
+                .Indexes.CreateOneAsync(indexModel, cancellationToken: cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to Create TTL index {Name} on {Collection}", name, typeof(T).DataEntityName());
+        }
+    }
+}

--- a/src/Processor/Data/MongoDbOptions.cs
+++ b/src/Processor/Data/MongoDbOptions.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Defra.TradeImportsProcessor.Processor.Data;
+
+public class MongoDbOptions
+{
+    public const string SectionName = "Mongo";
+
+    [Required]
+    public string? DatabaseUri { get; set; }
+
+    [Required]
+    public string? DatabaseName { get; set; }
+
+    public bool QueryLogging { get; set; }
+}

--- a/src/Processor/Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/Processor/Endpoints/EndpointRouteBuilderExtensions.cs
@@ -2,9 +2,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
 using Amazon.SQS.Model;
+using Defra.TradeImportsProcessor.Processor.Configuration;
 using Defra.TradeImportsProcessor.Processor.Consumers;
+using Defra.TradeImportsProcessor.Processor.Data;
+using Defra.TradeImportsProcessor.Processor.Data.Extensions;
 using Defra.TradeImportsProcessor.Processor.Models.CustomsDeclarations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver.Linq;
 using SlimMessageBus;
 using SlimMessageBus.Host;
 
@@ -90,5 +95,88 @@ public static class EndpointRouteBuilderExtensions
                 new KeyValuePair<string, object>("Sqs_Message", new Message { MessageId = Guid.NewGuid().ToString() }),
             },
         };
+    }
+
+    public static void MapRawMessageEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("raw-messages", GetByFilter).RequireAuthorization();
+        app.MapGet("raw-messages/{messageId}", Get).RequireAuthorization();
+        app.MapGet("raw-messages/{messageId}/json", GetJson).RequireAuthorization();
+    }
+
+    [HttpGet]
+    private static async Task<IResult> GetByFilter(
+        [FromQuery] string? resourceId,
+        [FromQuery] string? messageId,
+        [FromServices] IDbContext dbContext,
+        [FromServices] IOptions<RawMessageLoggingOptions> options,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!options.Value.Enabled)
+            return Results.NotFound();
+
+        var query = from entity in dbContext.RawMessages select entity;
+        var filtered = false;
+
+        if (!string.IsNullOrWhiteSpace(resourceId))
+        {
+            query = from entity in query where entity.ResourceId == resourceId select entity;
+            filtered = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(messageId))
+        {
+            query = from entity in query where entity.MessageId == messageId select entity;
+            filtered = true;
+        }
+
+        if (!filtered)
+            return Results.BadRequest("At least one filter param must be specified");
+
+        var results = await query
+            .OrderBy(x => x.Updated)
+            .Take(100)
+            .ToListWithFallbackAsync(cancellationToken: cancellationToken);
+
+        return Results.Ok(results);
+    }
+
+    [HttpGet]
+    private static async Task<IResult> Get(
+        [FromRoute] string messageId,
+        [FromServices] IDbContext dbContext,
+        [FromServices] IOptions<RawMessageLoggingOptions> options,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!options.Value.Enabled)
+            return Results.NotFound();
+
+        var entity = await dbContext.RawMessages.FirstOrDefaultAsync(
+            x => x.MessageId == messageId,
+            cancellationToken: cancellationToken
+        );
+
+        return entity is not null ? Results.Ok(entity) : Results.NotFound();
+    }
+
+    [HttpGet]
+    private static async Task<IResult> GetJson(
+        [FromRoute] string messageId,
+        [FromServices] IDbContext dbContext,
+        [FromServices] IOptions<RawMessageLoggingOptions> options,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!options.Value.Enabled)
+            return Results.NotFound();
+
+        var entity = await dbContext.RawMessages.FirstOrDefaultAsync(
+            x => x.MessageId == messageId,
+            cancellationToken: cancellationToken
+        );
+
+        return entity is not null ? Results.Content(entity.Message, "application/json") : Results.NotFound();
     }
 }

--- a/src/Processor/Extensions/OptionsExtensions.cs
+++ b/src/Processor/Extensions/OptionsExtensions.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Defra.TradeImportsProcessor.Processor.Extensions;
@@ -8,7 +6,6 @@ public static class OptionsExtensions
 {
     public static OptionsBuilder<TOptions> AddValidateOptions<TOptions>(
         this IServiceCollection services,
-        IConfiguration configuration,
         string section
     )
         where TOptions : class

--- a/src/Processor/Processor.csproj
+++ b/src/Processor/Processor.csproj
@@ -33,5 +33,7 @@
     <PackageReference Include="SlimMessageBus.Host.AzureServiceBus" Version="3.2.0" />
     <PackageReference Include="SlimMessageBus.Host.Serialization.SystemTextJson" Version="3.2.0" />
     <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
+    <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.4.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Processor/Program.cs
+++ b/src/Processor/Program.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsProcessor.Processor.Authentication;
+using Defra.TradeImportsProcessor.Processor.Data.Extensions;
 using Defra.TradeImportsProcessor.Processor.Endpoints;
 using Defra.TradeImportsProcessor.Processor.Extensions;
 using Defra.TradeImportsProcessor.Processor.Health;
@@ -63,6 +64,8 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
 
     builder.Services.AddConsumers(builder.Configuration);
     builder.Services.AddCustomMetrics();
+
+    builder.Services.AddDbContext(builder.Configuration, integrationTest);
 }
 
 static WebApplication BuildWebApplication(WebApplicationBuilder builder)
@@ -75,6 +78,7 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder)
     app.UseHeaderPropagation();
     app.UseMiddleware<MetricsMiddleware>();
     app.MapReplayEndpoints();
+    app.MapRawMessageEndpoints();
     app.UseExceptionHandler(
         new ExceptionHandlerOptions
         {

--- a/src/Processor/appsettings.Development.json
+++ b/src/Processor/appsettings.Development.json
@@ -1,7 +1,8 @@
 {
   "Mongo": {
-    "DatabaseUri": "mongodb://127.0.0.1:27017",
-    "DatabaseName": "trade-imports-processor"
+    "DatabaseUri": "mongodb://127.0.0.1:27017/?directConnection=true",
+    "DatabaseName": "trade-imports-processor",
+    "QueryLogging": true
   },
   "DetailedErrors": true,
   "AllowedHosts": "*",

--- a/src/Processor/appsettings.cdp.dev.json
+++ b/src/Processor/appsettings.cdp.dev.json
@@ -1,4 +1,10 @@
 {
+  "Mongo": {
+    "QueryLogging": true
+  },
+  "RawMessageLogging": {
+    "Enabled": true
+  },
   "DataApi": {
     "BaseAddress": "https://trade-imports-data-api.dev.cdp-int.defra.cloud"
   },

--- a/src/Processor/appsettings.json
+++ b/src/Processor/appsettings.json
@@ -44,6 +44,9 @@
       "Topic": "notification-topic",
       "Subscription": "btms"
     }
+  },
+  "RawMessageLogging": {
+    "Enabled": false
   }
 }
 

--- a/tests/Processor.IntegrationTests/TestBase/ServiceBusTestBase.cs
+++ b/tests/Processor.IntegrationTests/TestBase/ServiceBusTestBase.cs
@@ -2,7 +2,7 @@ using Azure.Messaging.ServiceBus;
 
 namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.TestBase;
 
-public class ServiceBusTestBase(string topicName, string subscriptionName) : IAsyncLifetime
+public class ServiceBusTestBase(string topicName, string subscriptionName) : TestBase, IAsyncLifetime
 {
     private const string ConnectionString =
         "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true";

--- a/tests/Processor.IntegrationTests/TestBase/TestBase.cs
+++ b/tests/Processor.IntegrationTests/TestBase/TestBase.cs
@@ -1,0 +1,18 @@
+using System.Net.Http.Headers;
+
+namespace Defra.TradeImportsProcessor.Processor.IntegrationTests.TestBase;
+
+public abstract class TestBase
+{
+    protected static HttpClient CreateHttpClient()
+    {
+        var httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:8080") };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            // See compose.yml for username, password and scope configuration
+            Convert.ToBase64String("IntegrationTests:integration-tests-pwd"u8.ToArray())
+        );
+
+        return httpClient;
+    }
+}

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -1,0 +1,13 @@
+namespace Defra.TradeImportsProcessor.Testing;
+
+public static class Endpoints
+{
+    public static class RawMessages
+    {
+        private const string Root = "/raw-messages";
+
+        public static string Get(string messageId) => $"{Root}/{messageId}";
+
+        public static string GetJson(string messageId) => $"{Get(messageId)}/json";
+    }
+}


### PR DESCRIPTION
Add ability to save the incoming messages being consumed in the processor.

Messages will be written to Mongo and the following endpoints exist to retrieve the data once it's been saved:

`GET raw-messages?resourceId=X&messageId=Y` - find all matching messages by `resourceId` (CHED or MRN or GmrId) or `messageId` (will be seen in logs during operation)
`GET raw-messages/{messageId}` - find a specific message
`GET raw-messages/{messageId}/json` - display the raw JSON for the specified `messageId` (this will be the endpoint used to grab the message and concert it into a test scenario

Saved messages have a TTL of 7 days (max can be 30). This can be updated in config as needed.

Saving of messages is turned on in CDP DEV only and also in local development.

Headers are also stored if needed.

If raw message logging is not enabled, it will not register the interceptor in DI at all therefore no effect on system performance.