### PR TITLE
CDMS-962: Add Modify, then skip it with improved logging

### DIFF
--- a/src/Processor/Consumers/ImportNotificationStatus.cs
+++ b/src/Processor/Consumers/ImportNotificationStatus.cs
@@ -7,6 +7,7 @@ public static class ImportNotificationStatus
     public const string Deleted = "DELETED";
     public const string Draft = "DRAFT";
     public const string InProgress = "IN_PROGRESS";
+    public const string Modify = "MODIFY";
     public const string PartiallyRejected = "PARTIALLY_REJECTED";
     public const string Replaced = "REPLACED";
     public const string Rejected = "REJECTED";

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -17,6 +17,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
         { ImportNotificationStatus.Deleted, 0 },
         { ImportNotificationStatus.Amend, 0 },
         { ImportNotificationStatus.Submitted, 0 },
+        { ImportNotificationStatus.Modify, 0 },
         { ImportNotificationStatus.InProgress, 1 },
         { ImportNotificationStatus.Cancelled, 2 },
         { ImportNotificationStatus.PartiallyRejected, 2 },
@@ -38,7 +39,11 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
 
         if (IsInvalidStatus(newNotification))
         {
-            logger.LogInformation("Skipping {ReferenceNumber} due to status", newNotification.ReferenceNumber);
+            logger.LogInformation(
+                "Skipping {ReferenceNumber} due to status {Status}",
+                newNotification.ReferenceNumber,
+                newNotification.Status
+            );
 
             return;
         }
@@ -166,6 +171,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
     private static bool IsInvalidStatus(ImportNotification notification)
     {
         return notification.Status == ImportNotificationStatus.Amend
+            || notification.Status == ImportNotificationStatus.Modify
             || notification.Status == ImportNotificationStatus.Draft
             || notification.ReferenceNumber.StartsWith("DRAFT", StringComparison.InvariantCultureIgnoreCase);
     }

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -143,6 +143,7 @@ public class NotificationConsumerTests
     [Theory]
     [InlineData(ImportNotificationStatus.Amend)]
     [InlineData(ImportNotificationStatus.Draft)]
+    [InlineData(ImportNotificationStatus.Modify)]
     public async Task OnHandle_WhenImportNotificationShouldNotBeProcessed_ThenItIsSkipped(string status)
     {
         var consumer = new NotificationConsumer(_mockLogger, _mockApi);


### PR DESCRIPTION
We want to skip AMEND, DRAFT and MODIFY Ipaffs statuses because they are states that we are not currently concerned about.