### PR TITLE
CDMS-926: Prevent Mongo serialisation affecting whatever headers are passing through

### DIFF
--- a/src/Processor/Consumers/RawMessageLoggingInterceptor.cs
+++ b/src/Processor/Consumers/RawMessageLoggingInterceptor.cs
@@ -59,7 +59,7 @@ public class RawMessageLoggingInterceptor<TMessage>(
                 ResourceId = GetResourceId(resourceType, jsonElement, context),
                 ResourceType = resourceType,
                 MessageId = context.GetMessageId(),
-                Headers = context.Headers.ToDictionary(x => x.Key, x => x.Value),
+                Headers = context.Headers.ToDictionary(x => x.Key, x => x.Value?.ToString()),
                 Message = jsonElement.GetRawText(),
                 ExpiresAt = DateTime.UtcNow.AddDays(options.Value.TtlDays),
             };

--- a/src/Processor/Data/Entities/RawMessageEntity.cs
+++ b/src/Processor/Data/Entities/RawMessageEntity.cs
@@ -23,7 +23,7 @@ public class RawMessageEntity : IDataEntity
     public required string ResourceType { get; set; }
 
     [JsonPropertyName("headers")]
-    public Dictionary<string, object> Headers { get; set; } = [];
+    public Dictionary<string, string?> Headers { get; set; } = [];
 
     [JsonPropertyName("messageId")]
     public required string MessageId { get; set; }


### PR DESCRIPTION
The acceptance tests highlighted an issue where a GUID was sent in the message headers from gateway to processor, which then broke saving the raw message. Despite the header value being a string, as our header property had object as the value type, it went through BSON serialisation and then errored.

For safety, the headers dictionary in our raw message entity has been changed to a value of nullable string, and all values as converted from the incoming message header as needed.

The acceptance tests running following merge will show this issue is sorted.