### PR TITLE
Add topic health check for alvs_topic

### DIFF
--- a/src/Processor/Health/ServiceCollectionExtensions.cs
+++ b/src/Processor/Health/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsProcessor.Processor.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace Defra.TradeImportsProcessor.Processor.Health;
@@ -20,6 +21,15 @@ public static class ServiceCollectionExtensions
             .AddAsbTopic(
                 "DMP GMRs",
                 sp => sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value.Gmrs,
+                tags: [WebApplicationExtensions.Extended],
+                timeout: TimeSpan.FromSeconds(10)
+            )
+            // Azure service bus emulator does not support the management client, which
+            // this health check uses. Therefore, it will only work against real Azure
+            .AddAsbTopic(
+                "IPAFFS topic (outgoing)",
+                sp => sp.GetRequiredService<IOptions<ServiceBusOptions>>().Value.Ipaffs,
+                failureStatus: HealthStatus.Degraded,
                 tags: [WebApplicationExtensions.Extended],
                 timeout: TimeSpan.FromSeconds(10)
             )

--- a/src/Processor/Services/ClearanceRequestStrategy.cs
+++ b/src/Processor/Services/ClearanceRequestStrategy.cs
@@ -39,6 +39,12 @@ public class ClearanceRequestStrategy(IMessageBus azureServiceBus, ILogger<Clear
             },
             cancellationToken: cancellationToken
         );
-        logger.LogInformation("{MRN} Message successfully published to IPAFFS for {MessageId}", resourceId, messageId);
+
+        logger.LogInformation(
+            "{MRN} {MessageType} Message successfully published to IPAFFS for {MessageId}",
+            resourceId,
+            ClearanceRequestMessageType,
+            messageId
+        );
     }
 }

--- a/src/Processor/Services/DecisionNotificationStrategy.cs
+++ b/src/Processor/Services/DecisionNotificationStrategy.cs
@@ -39,6 +39,12 @@ public class DecisionNotificationStrategy(IMessageBus azureServiceBus, ILogger<D
             },
             cancellationToken: cancellationToken
         );
-        logger.LogInformation("{MRN} Message successfully published to IPAFFS for {MessageId}", resourceId, messageId);
+
+        logger.LogInformation(
+            "{MRN} {MessageType} Message successfully published to IPAFFS for {MessageId}",
+            resourceId,
+            DecisionNotificationMessageType,
+            messageId
+        );
     }
 }

--- a/src/Processor/Services/FinalisationStrategy.cs
+++ b/src/Processor/Services/FinalisationStrategy.cs
@@ -38,6 +38,12 @@ public class FinalisationStrategy(IMessageBus azureServiceBus, ILogger<Finalisat
             },
             cancellationToken: cancellationToken
         );
-        logger.LogInformation("{MRN} Message successfully published to IPAFFS for {MessageId}", resourceId, messageId);
+
+        logger.LogInformation(
+            "{MRN} {MessageType} Message successfully published to IPAFFS for {MessageId}",
+            resourceId,
+            FinalisationMessageType,
+            messageId
+        );
     }
 }

--- a/src/Processor/Utils/Http/Proxy.cs
+++ b/src/Processor/Utils/Http/Proxy.cs
@@ -7,7 +7,7 @@ namespace Defra.TradeImportsProcessor.Processor.Utils.Http;
 
 public static class Proxy
 {
-    private const string ProxyClient = "proxy";
+    public const string ProxyClient = "proxy";
 
     [ExcludeFromCodeCoverage]
     public static void AddHttpProxyClient(this IServiceCollection services)


### PR DESCRIPTION
Ahead of the processor being in cutover mode, this PR will add a health check to allow us to see that we can connect to the alvs_topic in prod.