### PR TITLE
Rename field to plural to match was it was originally and to avoid a deserialisation error in DMP

### DIFF
--- a/src/Processor/Models/Ipaffs/Check.cs
+++ b/src/Processor/Models/Ipaffs/Check.cs
@@ -13,6 +13,6 @@ public class Check
     [JsonPropertyName("decisionValidUntil")]
     public string? DecisionValidUntil { get; set; }
 
-    [JsonPropertyName("decisionReason")]
-    public string[]? DecisionReason { get; set; }
+    [JsonPropertyName("decisionReasons")]
+    public string[]? DecisionReasons { get; set; }
 }

--- a/src/Processor/Models/Ipaffs/DecisionNotification.cs
+++ b/src/Processor/Models/Ipaffs/DecisionNotification.cs
@@ -42,7 +42,7 @@ public class DecisionNotification(string mrn, ClearanceDecision clearanceDecisio
                         CheckCode = check.CheckCode,
                         DecisionCode = check.DecisionCode,
                         DecisionValidUntil = check.DecisionsValidUntil?.ToString("yyyyMMddHHmm"),
-                        DecisionReason = check.DecisionReasons,
+                        DecisionReasons = check.DecisionReasons,
                     })
                     .ToArray(),
             })

--- a/tests/Processor.IntegrationTests/Consumers/ResourceEventsConsumerTests.WhenDecisionNotificationSent_ThenDecisionNotificationIsSentToAlvsServiceBusTopic.verified.json
+++ b/tests/Processor.IntegrationTests/Consumers/ResourceEventsConsumerTests.WhenDecisionNotificationSent_ThenDecisionNotificationIsSentToAlvsServiceBusTopic.verified.json
@@ -18,7 +18,7 @@
           "checkCode": "H219",
           "decisionCode": "X00",
           "decisionValidUntil": "202501081200",
-          "decisionReason": [
+          "decisionReasons": [
             "Test reason 1",
             "Test reason 2"
           ]


### PR DESCRIPTION
DMP uses `decisionReason` but it knows it as a string and not an array. The IPAFFS SOAP API used to produce output with field name `decisionsReasons` as an array. DMP doesn't actually use the field in any of its logic but in BTMS changing the field  name, we have now clashed with what is in DMP and it's throwing a deserialisation error.

Therefore this PR reverts the logic and retains the plural name of the field.