### PR TITLE
Allow publishing to IPAFFS to be disabled and disable it in perf test

### DIFF
--- a/src/Processor/Configuration/BtmsOptions.cs
+++ b/src/Processor/Configuration/BtmsOptions.cs
@@ -5,4 +5,6 @@ public class BtmsOptions
     public const string SectionName = "Btms";
 
     public OperatingMode OperatingMode { get; init; } = OperatingMode.Default;
+
+    public bool PublishToIpaffs { get; init; } = true;
 }

--- a/src/Processor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Processor/Extensions/ServiceCollectionExtensions.cs
@@ -286,7 +286,7 @@ public static class ServiceCollectionExtensions
             .ValidateDataAnnotations()
             .Get();
 
-        if (btmsOptions.OperatingMode == OperatingMode.Cutover)
+        if (btmsOptions is { OperatingMode: OperatingMode.Cutover, PublishToIpaffs: true })
         {
             services.AddScoped<IIpaffsStrategy, DecisionNotificationStrategy>();
             services.AddScoped<IIpaffsStrategy, ClearanceRequestStrategy>();

--- a/src/Processor/appsettings.cdp.perf-test.json
+++ b/src/Processor/appsettings.cdp.perf-test.json
@@ -11,5 +11,8 @@
       "Topic": "defra.trade.imports.notification-topic-perf-test",
       "Subscription": "btms"
     }
+  },
+  "Btms": {
+    "PublishToIpaffs": false
   }
 }


### PR DESCRIPTION
As per PR title.

In perf test we don't want to publish to anything real but we do want to consume.