### PR TITLE
CDMS-1431: Clarify NotificationConsumer skip log messages

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -32,7 +32,7 @@ jobs:
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Publish Hot Fix
-        uses: DEFRA/cdp-build-action/build-hotfix@main
+        uses: DEFRA/cdp-build-action/build-hotfix@dfb7dbaa4129b6e7e6b250c043d06628b32f8167
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
     ## SonarCloud

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -166,7 +166,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
             return true;
 
         logger.LogInformation(
-            "Skipping {ReferenceNumber} because unexpected IPAFFS State Transition -  Previous state [{OldStatus}], new state [{NewStatus}]",
+            "Skipping {ReferenceNumber} due to an unexpected IPAFFS State Transition -  Previous state [{OldStatus}], new state [{NewStatus}]",
             newNotification.ReferenceNumber,
             existingNotification.Status,
             newNotification.Status

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -153,10 +153,8 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
         )
         {
             logger.LogInformation(
-                "Skipping {ReferenceNumber} because unexpected IPAFFS State Transition -  Previous state [{OldStatus}], new state [{NewStatus}] or older {NewTime:O} < {OldTime:O}",
+                "Skipping {ReferenceNumber} as timestamp on latest message received {NewTime:O} is before the timestamp {OldTime:O} on the current message.  This message appears to have been sent out of sequence.",
                 newNotification.ReferenceNumber,
-                existingNotification.Status,
-                newNotification.Status,
                 newNotification.UpdatedSource,
                 existingNotification.UpdatedSource
             );
@@ -168,12 +166,10 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
             return true;
 
         logger.LogInformation(
-            "Skipping {ReferenceNumber} because unexpected IPAFFS State Transition -  Previous state [{OldStatus}], new state [{NewStatus}] or older {NewTime:O} < {OldTime:O}",
+            "Skipping {ReferenceNumber} because unexpected IPAFFS State Transition -  Previous state [{OldStatus}], new state [{NewStatus}]",
             newNotification.ReferenceNumber,
             existingNotification.Status,
-            newNotification.Status,
-            newNotification.UpdatedSource,
-            existingNotification.UpdatedSource
+            newNotification.Status
         );
 
         return false;


### PR DESCRIPTION
Separate log messages are now used to distinguish between notifications skipped due to an out-of-sequence timestamp and those skipped due to an invalid IPAFFS state transition. This provides more precise diagnostic information.
