### PR TITLE
CDMS-1477: Integrate SplitConsignment status into NotificationConsumer

### DIFF
--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -35,6 +35,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
         (ImportNotificationStatus.InProgress, ImportNotificationStatus.Rejected),
         (ImportNotificationStatus.InProgress, ImportNotificationStatus.Replaced),
         (ImportNotificationStatus.InProgress, ImportNotificationStatus.PartiallyRejected),
+        (ImportNotificationStatus.InProgress, ImportNotificationStatus.SplitConsignment),
         // Partially rejected
         (ImportNotificationStatus.PartiallyRejected, ImportNotificationStatus.PartiallyRejected),
         (ImportNotificationStatus.PartiallyRejected, ImportNotificationStatus.SplitConsignment),

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -288,6 +288,7 @@ public class NotificationConsumerTests
     [InlineData(ImportNotificationStatus.Validated)]
     [InlineData(ImportNotificationStatus.Rejected)]
     [InlineData(ImportNotificationStatus.PartiallyRejected)]
+    [InlineData(ImportNotificationStatus.SplitConsignment)]
     public async Task OnHandle_WhenNewImportNotificationIsInProgress_AndTheExistingIsMoreMature_Skip(
         string existingStatus
     )


### PR DESCRIPTION
Adds `SplitConsignment` as a valid status transition from `InProgress`. This change also updates the skip logic to correctly identify `SplitConsignment` as a more mature status, preventing out-of-sequence updates when a notification is already split.
