### PR TITLE
CDMS-1511: Allow additional notification state transitions

### DIFF
--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -176,6 +176,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.InProgress),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Deleted),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Cancelled),
+            (ImportNotificationStatus.Submitted, ImportNotificationStatus.Modify),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Validated), // auto clearance process
             // In progress
             (ImportNotificationStatus.InProgress, ImportNotificationStatus.InProgress),

--- a/src/Processor/Consumers/NotificationConsumer.cs
+++ b/src/Processor/Consumers/NotificationConsumer.cs
@@ -175,6 +175,7 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Amend),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.InProgress),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Deleted),
+            (ImportNotificationStatus.Submitted, ImportNotificationStatus.Cancelled),
             (ImportNotificationStatus.Submitted, ImportNotificationStatus.Validated), // auto clearance process
             // In progress
             (ImportNotificationStatus.InProgress, ImportNotificationStatus.InProgress),
@@ -186,6 +187,8 @@ public class NotificationConsumer(ILogger<NotificationConsumer> logger, ITradeIm
             (ImportNotificationStatus.InProgress, ImportNotificationStatus.PartiallyRejected),
             (ImportNotificationStatus.InProgress, ImportNotificationStatus.Modify),
             (ImportNotificationStatus.InProgress, ImportNotificationStatus.SplitConsignment),
+            (ImportNotificationStatus.InProgress, ImportNotificationStatus.Submitted),
+            (ImportNotificationStatus.InProgress, ImportNotificationStatus.Deleted),
             // Partially rejected
             (ImportNotificationStatus.PartiallyRejected, ImportNotificationStatus.PartiallyRejected),
             (ImportNotificationStatus.PartiallyRejected, ImportNotificationStatus.SplitConsignment),

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -344,7 +344,7 @@ public class NotificationConsumerTests
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Validated, true)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.PartiallyRejected, false)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Rejected, false)]
-    [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Modify, false)]
+    [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Modify, true)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Cancelled, true)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Replaced, false)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.SplitConsignment, false)]

--- a/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
+++ b/tests/Processor.Tests/Consumers/NotificationConsumerTests.cs
@@ -345,7 +345,7 @@ public class NotificationConsumerTests
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.PartiallyRejected, false)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Rejected, false)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Modify, false)]
-    [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Cancelled, false)]
+    [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Cancelled, true)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.Replaced, false)]
     [InlineData(ImportNotificationStatus.Submitted, ImportNotificationStatus.SplitConsignment, false)]
     // InProgress
@@ -357,8 +357,8 @@ public class NotificationConsumerTests
     [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Replaced, true)]
     [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.PartiallyRejected, true)]
     [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Modify, true)]
-    [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Submitted, false)]
-    [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Deleted, false)]
+    [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Submitted, true)]
+    [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.Deleted, true)]
     [InlineData(ImportNotificationStatus.InProgress, ImportNotificationStatus.SplitConsignment, true)]
     // PartiallyRejected
     [InlineData(ImportNotificationStatus.PartiallyRejected, ImportNotificationStatus.PartiallyRejected, true)]


### PR DESCRIPTION
Adds valid transitions for `ImportNotificationStatus` from `Submitted` to `Cancelled`, and from `InProgress` to `Submitted` and `Deleted`.
